### PR TITLE
more fields in views, load PU locations

### DIFF
--- a/app/models/concerns/locations/coded.rb
+++ b/app/models/concerns/locations/coded.rb
@@ -6,8 +6,8 @@ module Locations
       friendly_id :code
       validates :code, presence: true
       validates :code, uniqueness: true
-      validates_format_of :code, with: /\A[a-z][a-z0-9]{2,10}\Z/,
-        message: 'must be at least three characters, all lowercase letters or numbers, and may not start with a number'
+      validates_format_of :code, with: /\A[a-z][a-z0-9]{0,11}\Z/,
+        message: 'must be at least one character, all lowercase letters or numbers, and may not start with a number'
     end
   end
 end

--- a/app/views/locations/delivery_locations/index.html.erb
+++ b/app/views/locations/delivery_locations/index.html.erb
@@ -4,12 +4,13 @@
   <thead>
     <tr>
       <th>Label</th>
+      <th>Library</th>
       <th>Address</th>
       <th>Phone Number</th>
       <th>Contact E-mail</th>
       <th>GFA Pickup</th>
       <th>Staff only</th>
-      <th>Pickup Location</th>            
+      <th>Pickup Location</th>
       <th colspan="3"></th>
     </tr>
   </thead>
@@ -17,14 +18,14 @@
   <tbody>
     <% @delivery_locations.each do |delivery_location| %>
       <tr>
-        <td><%= delivery_location.label %></td>
+        <td><%= link_to delivery_location.label, delivery_location %></td>
+        <td><%= link_to delivery_location.library.code, delivery_location.library %></td>
         <td><%= delivery_location.address %></td>
         <td><%= delivery_location.phone_number %></td>
         <td><%= delivery_location.contact_email %></td>
         <td><%= delivery_location.gfa_pickup %></td>
         <td><%= delivery_location.staff_only %></td>
-        <td><%= delivery_location.pickup_location %></td>                
-        <td><%= link_to 'Show', delivery_location %></td>
+        <td><%= delivery_location.pickup_location %></td>
         <td><%= link_to 'Edit', edit_delivery_location_path(delivery_location) %></td>
         <td><%= link_to 'Destroy', delivery_location, method: :delete, data: { confirm: 'Are you sure?' } %></td>
       </tr>

--- a/app/views/locations/delivery_locations/index.json.jbuilder
+++ b/app/views/locations/delivery_locations/index.json.jbuilder
@@ -5,6 +5,7 @@ json.array!(@delivery_locations) do |delivery_location|
   else
     json.url delivery_location_url(delivery_location, format: :json)
   end
-  
+  json.partial! 'locations/holding_locations/json_partials/library',
+  library: delivery_location.library
 
 end

--- a/app/views/locations/delivery_locations/show.html.erb
+++ b/app/views/locations/delivery_locations/show.html.erb
@@ -4,6 +4,11 @@
 </p>
 
 <p>
+  <strong>Library:</strong>
+  <%= link_to @delivery_location.library.code, @delivery_location.library %>
+</p>
+
+<p>
   <strong>Address:</strong>
   <%= @delivery_location.address %>
 </p>
@@ -31,11 +36,6 @@
 <p>
   <strong>Pickup Location:</strong>
   <%= @delivery_location.pickup_location %>
-</p>
-
-<p>
-  <strong>Library:</strong>
-  <%= @delivery_location.library.label %>
 </p>
 
 <%= link_to 'Edit', edit_delivery_location_path(@delivery_location) %> |

--- a/app/views/locations/delivery_locations/show.json.jbuilder
+++ b/app/views/locations/delivery_locations/show.json.jbuilder
@@ -1,1 +1,4 @@
 json.partial! 'locations/delivery_locations/show_single', delivery_location: @delivery_location
+
+json.partial! 'locations/holding_locations/json_partials/library',
+  library: @delivery_location.library

--- a/app/views/locations/holding_locations/index.html.erb
+++ b/app/views/locations/holding_locations/index.html.erb
@@ -5,6 +5,12 @@
     <tr>
       <th>Label</th>
       <th>Code</th>
+      <th>Library</th>
+      <th>Aeon Location</th>
+      <th>ReCAP Electronic Delivery Location</th>
+      <th>Open</th>
+      <th>Requestable</th>
+      <th>Always Requestable</th>
       <th colspan="3"></th>
     </tr>
   </thead>
@@ -12,9 +18,14 @@
   <tbody>
     <% @holding_locations.each do |holding_location| %>
       <tr>
-        <td><%= holding_location.label %></td>
+        <td><%= link_to holding_location.label, holding_location %></td>
         <td><%= holding_location.code %></td>
-        <td><%= link_to 'Show', holding_location %></td>
+        <td><%= link_to holding_location.library.code, holding_location.library %></td>
+        <td><%= holding_location.aeon_location %></td>
+        <td><%= holding_location.recap_electronic_delivery_location %></td>
+        <td><%= holding_location.open %></td>
+        <td><%= holding_location.requestable %></td>
+        <td><%= holding_location.always_requestable %></td>
         <td><%= link_to 'Edit', edit_holding_location_path(holding_location) %></td>
         <td><%= link_to 'Destroy', holding_location, method: :delete, data: { confirm: 'Are you sure?' } %></td>
       </tr>

--- a/app/views/locations/holding_locations/show.html.erb
+++ b/app/views/locations/holding_locations/show.html.erb
@@ -8,6 +8,49 @@
   <%= @holding_location.code %>
 </p>
 
+<p>
+  <strong>Library:</strong>
+  <%= link_to @holding_location.library.code, @holding_location.library %>
+</p>
+
+<p>
+  <strong>Aeon Location:</strong>
+  <%= @holding_location.aeon_location %>
+</p>
+
+<p>
+  <strong>ReCAP Electronic Delivery Location:</strong>
+  <%= @holding_location.recap_electronic_delivery_location %>
+</p>
+
+<p>
+  <strong>Open:</strong>
+  <%= @holding_location.open %>
+</p>
+
+<p>
+  <strong>Reuqestable:</strong>
+  <%= @holding_location.requestable %>
+</p>
+
+<p>
+  <strong>Always Requestable:</strong>
+  <%= @holding_location.always_requestable %>
+</p>
+
+<p>
+	<dl>
+	  <dt><strong>Delivery Locations:</strong></dt>
+	  <dd>
+      <ul>
+        <% @holding_location.delivery_locations.each do |dl| %>
+        <li><%= link_to dl.label, dl %></li>
+        <% end %>
+      </ul>
+		</dd>
+	</dl>
+</p>
+
 <%= link_to 'Edit', edit_holding_location_path(@holding_location) %> |
 <%= link_to 'View as JSON', format: :json %> |
 <%= link_to 'All Holding Locations', holding_locations_path %>

--- a/app/views/locations/libraries/index.html.erb
+++ b/app/views/locations/libraries/index.html.erb
@@ -12,9 +12,8 @@
   <tbody>
     <% @libraries.each do |library| %>
       <tr>
-        <td><%= library.label %></td>
+        <td><%= link_to library.label, library %></td>
         <td><%= library.code %></td>
-        <td><%= link_to 'Show', library %></td>
         <td><%= link_to 'Edit', edit_library_path(library) %></td>
         <td><%= link_to 'Destroy', library, method: :delete, data: { confirm: 'Are you sure?' } %></td>
       </tr>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 Locations::Engine.routes.draw do
-  resources :holding_locations
-  resources :libraries
-  resources :delivery_locations
+  resources :holding_locations, path_names: { new: "create" }
+  resources :libraries, path_names: { new: "create"}
+  resources :delivery_locations, path_names: { new: "create"}
   root 'home#index'
 end

--- a/lib/generators/locations/install_generator.rb
+++ b/lib/generators/locations/install_generator.rb
@@ -2,9 +2,11 @@ require 'rails/generators'
 
 module Locations
   class InstallGenerator < Rails::Generators::Base
+    source_root File.expand_path('../../../locations', __FILE__)
 
     def add_gems
       gem 'bootstrap-sass', '~> 3.3.4'
+      gem 'yaml_db', '~> 0.3.0'
       Bundler.with_clean_env do
         run "bundle install"
       end
@@ -13,6 +15,7 @@ module Locations
     def friendly_id
       gem 'friendly_id', '~> 5.1.0'
       generate 'friendly_id'
+      gsub_file 'config/initializers/friendly_id.rb', 'new edit', 'create edit'
     end
 
     def inject_routes
@@ -25,5 +28,11 @@ module Locations
       rake 'locations:install:migrations'
       rake "db:migrate"
     end
+
+    def add_locations
+      copy_file "data.yml", "db/data.yml"
+      rake 'db:data:load'
+    end
+
   end
 end

--- a/lib/locations/data.yml
+++ b/lib/locations/data.yml
@@ -1,0 +1,4101 @@
+
+---
+locations_delivery_locations:
+  columns:
+  - id
+  - label
+  - address
+  - phone_number
+  - contact_email
+  - staff_only
+  - created_at
+  - updated_at
+  - locations_library_id
+  - gfa_pickup
+  - pickup_location
+  records: 
+  - - 1
+    - Plasma Physics Library
+    - Forrestal Campus Princeton, NJ 08544
+    - 609-243-3565
+    - ppllib@princeton.edu
+    - false
+    - '2015-06-02 16:39:37.893126'
+    - '2015-06-02 16:39:37.893126'
+    - 14
+    - PQ
+    - true
+  - - 2
+    - Technical Services
+    - 693 Alexander Rd. Princeton, NJ 08544
+    - 609-258-1470
+    - fstcirc@princeton.edu
+    - true
+    - '2015-06-02 16:39:37.933805'
+    - '2015-06-02 16:39:37.933805'
+    - 6
+    - QT
+    - false
+  - - 3
+    - Architecture Library
+    - School of Architecture Building, Second Floor Princeton, NJ 08544
+    - 609-258-3256
+    - ues@princeton.edu
+    - false
+    - '2015-06-02 16:39:37.981141'
+    - '2015-06-02 16:39:37.981141'
+    - 3
+    - PW
+    - true
+  - - 4
+    - East Asian Library
+    - Frist Campus Center, Room 317 Princeton, NJ 08544
+    - 609-258-3182
+    - gestcirc@princeton.edu
+    - false
+    - '2015-06-02 16:39:38.053510'
+    - '2015-06-02 16:39:38.053510'
+    - 4
+    - PL
+    - true
+  - - 5
+    - Engineering Library
+    - Friend Center for Engineering Education Princeton, NJ 08544
+    - 609-258-3200
+    - englib@princeton.edu
+    - false
+    - '2015-06-02 16:39:38.100058'
+    - '2015-06-02 16:39:38.100058'
+    - 5
+    - PT
+    - true
+  - - 6
+    - Firestone Library, Microforms
+    - One Washington Rd. Princeton, NJ 08544
+    - 609-258-3252
+    - microfms@princeton.edu
+    - false
+    - '2015-06-02 16:39:38.141123'
+    - '2015-06-02 16:39:38.141123'
+    - 6
+    - PF
+    - false
+  - - 7
+    - Marquand Library of Art and Archaeology
+    - McCormick Hall Princeton, NJ 08544
+    - 609-258-5863
+    - marquand@princeton.edu
+    - false
+    - '2015-06-02 16:39:38.184225'
+    - '2015-06-02 16:39:38.184225'
+    - 9
+    - PJ
+    - true
+  - - 8
+    - Mendel Music Library
+    - Woolworth Center Princeton, NJ 08544
+    - 609-258-3230
+    - muslib@princeton.edu
+    - false
+    - '2015-06-02 16:39:38.220424'
+    - '2015-06-02 16:39:38.220424'
+    - 11
+    - PK
+    - true
+  - - 9
+    - Mudd Manuscript Library
+    - 65 Olden Street Princeton, NJ 08544
+    - 609-258-6345
+    - mudd@princeton.edu
+    - false
+    - '2015-06-02 16:39:38.273692'
+    - '2015-06-02 16:39:38.273692'
+    - 10
+    - PH
+    - false
+  - - 10
+    - Stokes Library
+    - Wallace Hall, Lower Level Princeton, NJ 08544
+    - 609-258-5455
+    - piaprlib@princeton.edu
+    - false
+    - '2015-06-02 16:39:38.331935'
+    - '2015-06-02 16:39:38.331935'
+    - 17
+    - PM
+    - true
+  - - 11
+    - Lewis Library, Geosciences and Map Library
+    - Washington Road and Ivy Lane Princeton, NJ 08544
+    - 609-258-6004
+    - lewislib@princeton.edu
+    - false
+    - '2015-06-02 16:39:38.387872'
+    - '2015-06-02 16:39:38.387872'
+    - 8
+    - PN
+    - true
+  - - 12
+    - Firestone Library, Resource Sharing
+    - One Washington Rd. Princeton, NJ 08544
+    - 609-258-1470
+    - fstcirc@princeton.edu
+    - true
+    - '2015-06-02 16:39:38.445572'
+    - '2015-06-02 16:39:38.445572'
+    - 6
+    - QA
+    - false
+  - - 13
+    - Firestone Library, Rare Books & Special Collections Reading Room
+    - One Washington Rd. Princeton, NJ 08544
+    - 609-258-1470
+    - fstcirc@princeton.edu
+    - false
+    - '2015-06-02 16:39:38.491944'
+    - '2015-06-02 16:39:38.491944'
+    - 6
+    - PG
+    - false
+  - - 14
+    - Lewis Library
+    - Washington Road and Ivy Lane Princeton, NJ 08544
+    - 609-258-6004
+    - lewislib@princeton.edu
+    - false
+    - '2015-06-02 16:39:38.541597'
+    - '2015-06-02 16:39:38.541597'
+    - 8
+    - PN
+    - true
+  - - 15
+    - Firestone Library
+    - One Washington Rd. Princeton, NJ 08544
+    - 609-258-1470
+    - fstcirc@princeton.edu
+    - false
+    - '2015-06-02 16:39:38.594904'
+    - '2015-06-02 16:39:38.594904'
+    - 6
+    - PA
+    - true
+  - - 16
+    - ReCAP Reading Room
+    - One Washington Rd. Princeton, NJ 08544
+    - 609-258-1470
+    - fstcirc@princeton.edu
+    - false
+    - '2015-06-02 16:39:38.644145'
+    - '2015-06-02 16:39:38.644145'
+    - 6
+    - IL
+    - true
+  - - 17
+    - Humanities Resource Center
+    - 011 East Pyne Princeton, NJ 08544
+    - 609-258-1290
+    - fstcirc@princeton.edu
+    - false
+    - '2015-06-02 16:39:38.687229'
+    - '2015-06-02 16:39:38.687229'
+    - 7
+    - QV
+    - false
+  - - 18
+    - Broadcast Center
+    - 132 Lewis Library Princeton, NJ 08544
+    - 609-258-7872
+    - bctv@princeton.edu
+    - false
+    - '2015-06-02 16:39:38.733689'
+    - '2015-06-02 16:39:38.733689'
+    - 8
+    - PN
+    - false
+  - - 19
+    - Firestone Library, Costen
+    - One Washington Rd. Princeton, NJ 08544
+    - 609-258-1470
+    - fstcirc@princeton.edu
+    - false
+    - '2015-06-02 16:39:38.773386'
+    - '2015-06-02 16:39:38.773386'
+    - 6
+    - PG
+    - false
+  - - 20
+    - Firestone Library, Graphics Arts
+    - One Washington Rd. Princeton, NJ 08544
+    - 609-258-1470
+    - fstcirc@princeton.edu
+    - false
+    - '2015-06-02 16:39:38.836776'
+    - '2015-06-02 16:39:38.836776'
+    - 6
+    - PG
+    - false
+  - - 21
+    - Firestone Library, Numismatics
+    - One Washington Rd. Princeton, NJ 08544
+    - 609-258-1470
+    - fstcirc@princeton.edu
+    - false
+    - '2015-06-02 16:39:38.877712'
+    - '2015-06-02 16:39:38.877712'
+    - 6
+    - PG
+    - false
+  - - 22
+    - Firestone, Historic Maps
+    - One Washington Rd. Princeton, NJ 08544
+    - 609-258-1470
+    - fstcirc@princeton.edu
+    - false
+    - '2015-06-02 16:39:38.922154'
+    - '2015-06-02 16:39:38.922154'
+    - 6
+    - PG
+    - false
+  - - 23
+    - Technical Services, Database Maintenance
+    - 693 Alexander Rd. Princeton, NJ 08544
+    - 609-258-1470
+    - fstcirc@princeton.edu
+    - true
+    - '2015-06-02 16:39:38.969512'
+    - '2015-06-02 16:39:38.969512'
+    - 6
+    - QC
+    - false
+  - - 24
+    - East Asian Library. Microforms
+    - Frist Campus Center, Room 317 Princeton, NJ 08544
+    - 609-258-3182
+    - gestcirc@princeton.edu
+    - false
+    - '2015-06-02 16:39:39.019104'
+    - '2015-06-02 16:39:39.019104'
+    - 4
+    - QL
+    - false
+  - - 25
+    - Lewis Library (Rare)
+    - Washington Road and Ivy Lane Princeton, NJ 08544
+    - 609-258-6004
+    - lewislib@princeton.edu
+    - false
+    - '2015-06-02 16:39:39.075747'
+    - '2015-06-02 16:39:39.075747'
+    - 8
+    - PS
+    - false
+  - - 26
+    - Marquand Library of Art and Archaeology (Rare)
+    - McCormick Hall Princeton, NJ 08544
+    - 609-258-5863
+    - marquand@princeton.edu
+    - false
+    - '2015-06-02 16:39:39.120806'
+    - '2015-06-02 16:39:39.120806'
+    - 9
+    - PZ
+    - false
+  - - 27
+    - Mendel Music Library. Sound/Video
+    - Woolworth Center Princeton, NJ 08544
+    - 609-258-3230
+    - muslib@princeton.edu
+    - false
+    - '2015-06-02 16:39:39.161736'
+    - '2015-06-02 16:39:39.161736'
+    - 11
+    - QK
+    - false
+  - - 28
+    - Firestone Library, Microforms (Firestone Use Only)
+    - One Washington Rd. Princeton, NJ 08544
+    - 609-258-3252
+    - microfms@princeton.edu
+    - false
+    - '2015-06-02 16:39:39.212016'
+    - '2015-06-02 16:39:39.212016'
+    - 6
+    - PB
+    - false
+  - - 29
+    - Preservation
+    - One Washington Rd. Princeton, NJ 08544
+    - 609-258-1470
+    - fstcirc@princeton.edu
+    - true
+    - '2015-06-02 16:39:39.252620'
+    - '2015-06-02 16:39:39.252620'
+    - 6
+    - QP
+    - false
+
+---
+locations_libraries:
+  columns:
+  - id
+  - label
+  - code
+  - created_at
+  - updated_at
+  records: 
+  - - 1
+    - Forrestal Annex
+    - annexa
+    - '2015-06-02 16:39:37.120368'
+    - '2015-06-02 16:39:37.120368'
+  - - 2
+    - Fine Annex
+    - annexb
+    - '2015-06-02 16:39:37.172774'
+    - '2015-06-02 16:39:37.172774'
+  - - 3
+    - Architecture Library
+    - architecture
+    - '2015-06-02 16:39:37.204389'
+    - '2015-06-02 16:39:37.204389'
+  - - 4
+    - East Asian Library
+    - eastasian
+    - '2015-06-02 16:39:37.244882'
+    - '2015-06-02 16:39:37.244882'
+  - - 5
+    - Engineering Library
+    - engineering
+    - '2015-06-02 16:39:37.301533'
+    - '2015-06-02 16:39:37.301533'
+  - - 6
+    - Firestone Library
+    - firestone
+    - '2015-06-02 16:39:37.332288'
+    - '2015-06-02 16:39:37.332288'
+  - - 7
+    - Humanities Resource Center
+    - hrc
+    - '2015-06-02 16:39:37.371634'
+    - '2015-06-02 16:39:37.371634'
+  - - 8
+    - Lewis Library
+    - lewis
+    - '2015-06-02 16:39:37.412235'
+    - '2015-06-02 16:39:37.412235'
+  - - 9
+    - Marquand Library
+    - marquand
+    - '2015-06-02 16:39:37.448923'
+    - '2015-06-02 16:39:37.448923'
+  - - 10
+    - Mudd Manuscript Library
+    - mudd
+    - '2015-06-02 16:39:37.493164'
+    - '2015-06-02 16:39:37.493164'
+  - - 11
+    - Mendel Music Library
+    - mendel
+    - '2015-06-02 16:39:37.527953'
+    - '2015-06-02 16:39:37.527953'
+  - - 12
+    - Online
+    - online
+    - '2015-06-02 16:39:37.582166'
+    - '2015-06-02 16:39:37.582166'
+  - - 13
+    - Other Location
+    - other
+    - '2015-06-02 16:39:37.619514'
+    - '2015-06-02 16:39:37.619514'
+  - - 14
+    - Harold P. Furth Plasma Physics Library
+    - plasma
+    - '2015-06-02 16:39:37.662961'
+    - '2015-06-02 16:39:37.662961'
+  - - 15
+    - Rare Books and Special Collections
+    - rare
+    - '2015-06-02 16:39:37.714214'
+    - '2015-06-02 16:39:37.714214'
+  - - 16
+    - ReCAP
+    - recap
+    - '2015-06-02 16:39:37.742845'
+    - '2015-06-02 16:39:37.742845'
+  - - 17
+    - Stokes Library
+    - stokes
+    - '2015-06-02 16:39:37.804910'
+    - '2015-06-02 16:39:37.804910'
+
+---
+locations_holding_locations:
+  columns:
+  - id
+  - label
+  - code
+  - created_at
+  - updated_at
+  - locations_library_id
+  - aeon_location
+  - recap_electronic_delivery_location
+  - open
+  - requestable
+  - always_requestable
+  records: 
+  - - 1
+    - Forrestal Annex
+    - anxa
+    - '2015-06-02 16:39:39.458625'
+    - '2015-06-02 16:39:39.458625'
+    - 1
+    - false
+    - false
+    - false
+    - true
+    - false
+  - - 2
+    - 'Forrestal Annex: Documents Off-Site Storage'
+    - anxadoc
+    - '2015-06-02 16:39:39.615284'
+    - '2015-06-02 16:39:39.615284'
+    - 1
+    - false
+    - false
+    - false
+    - true
+    - false
+  - - 3
+    - 'Forrestal Annex: Temporary'
+    - anxafst
+    - '2015-06-02 16:39:39.754703'
+    - '2015-06-02 16:39:39.754703'
+    - 1
+    - false
+    - false
+    - false
+    - true
+    - false
+  - - 4
+    - 'Forrestal Annex: Locked Books'
+    - l
+    - '2015-06-02 16:39:39.904955'
+    - '2015-06-02 16:39:39.904955'
+    - 1
+    - false
+    - false
+    - false
+    - true
+    - false
+  - - 5
+    - 'Forrestal Annex: Princeton Collection'
+    - p
+    - '2015-06-02 16:39:40.068261'
+    - '2015-06-02 16:39:40.068261'
+    - 1
+    - false
+    - false
+    - false
+    - true
+    - false
+  - - 6
+    - 'Forrestal Annex: Annex A, Forrestal (Reserve)'
+    - res
+    - '2015-06-02 16:39:40.229432'
+    - '2015-06-02 16:39:40.229432'
+    - 1
+    - false
+    - false
+    - false
+    - true
+    - false
+  - - 7
+    - 'Forrestal Annex: Classics Theses'
+    - sct
+    - '2015-06-02 16:39:40.371126'
+    - '2015-06-02 16:39:40.371126'
+    - 1
+    - false
+    - false
+    - false
+    - true
+    - false
+  - - 8
+    - 'Forrestal Annex: German Languages Theses'
+    - sdt
+    - '2015-06-02 16:39:40.527513'
+    - '2015-06-02 16:39:40.527513'
+    - 1
+    - false
+    - false
+    - false
+    - true
+    - false
+  - - 9
+    - 'Forrestal Annex: English Theses'
+    - set
+    - '2015-06-02 16:39:40.702956'
+    - '2015-06-02 16:39:40.702956'
+    - 1
+    - false
+    - false
+    - false
+    - true
+    - false
+  - - 10
+    - 'Forrestal Annex: History Theses'
+    - sht
+    - '2015-06-02 16:39:40.850742'
+    - '2015-06-02 16:39:40.850742'
+    - 1
+    - false
+    - false
+    - false
+    - true
+    - false
+  - - 11
+    - 'Forrestal Annex: Philosophy Theses'
+    - spt
+    - '2015-06-02 16:39:40.990882'
+    - '2015-06-02 16:39:40.990882'
+    - 1
+    - false
+    - false
+    - false
+    - true
+    - false
+  - - 12
+    - 'Forrestal Annex: Romance Theses'
+    - srt
+    - '2015-06-02 16:39:41.153558'
+    - '2015-06-02 16:39:41.153558'
+    - 1
+    - false
+    - false
+    - false
+    - true
+    - false
+  - - 13
+    - 'Forrestal Annex: Engineering'
+    - stlo
+    - '2015-06-02 16:39:41.324624'
+    - '2015-06-02 16:39:41.324624'
+    - 1
+    - false
+    - false
+    - false
+    - true
+    - false
+  - - 14
+    - 'Forrestal Annex: Theses Collection'
+    - t
+    - '2015-06-02 16:39:41.496980'
+    - '2015-06-02 16:39:41.496980'
+    - 1
+    - false
+    - false
+    - false
+    - true
+    - false
+  - - 15
+    - Fine Annex
+    - anxb
+    - '2015-06-02 16:39:41.640754'
+    - '2015-06-02 16:39:41.640754'
+    - 2
+    - false
+    - false
+    - false
+    - true
+    - false
+  - - 16
+    - 'Fine Annex: Locked'
+    - anxbl
+    - '2015-06-02 16:39:41.799309'
+    - '2015-06-02 16:39:41.799309'
+    - 2
+    - false
+    - false
+    - false
+    - true
+    - false
+  - - 17
+    - 'Fine Annex: Non Circulating'
+    - anxbnc
+    - '2015-06-02 16:39:41.957989'
+    - '2015-06-02 16:39:41.957989'
+    - 2
+    - false
+    - false
+    - false
+    - false
+    - false
+  - - 18
+    - 'Fine Annex: Microforms '
+    - stf
+    - '2015-06-02 16:39:42.120674'
+    - '2015-06-02 16:39:42.120674'
+    - 2
+    - false
+    - false
+    - true
+    - false
+    - false
+  - - 19
+    - Architecture Library
+    - ues
+    - '2015-06-02 16:39:42.263416'
+    - '2015-06-02 16:39:42.263416'
+    - 3
+    - false
+    - false
+    - true
+    - false
+    - false
+  - - 20
+    - 'Architecture Library: Indexes'
+    - uesia
+    - '2015-06-02 16:39:42.411500'
+    - '2015-06-02 16:39:42.411500'
+    - 3
+    - false
+    - false
+    - true
+    - false
+    - false
+  - - 21
+    - 'Architecture Library: Librarian''s Office'
+    - uesla
+    - '2015-06-02 16:39:42.568104'
+    - '2015-06-02 16:39:42.568104'
+    - 3
+    - false
+    - false
+    - false
+    - false
+    - false
+  - - 22
+    - 'Architecture Library: Reserve 3 Hour'
+    - ueso
+    - '2015-06-02 16:39:42.699613'
+    - '2015-06-02 16:39:42.699613'
+    - 3
+    - false
+    - false
+    - false
+    - false
+    - false
+  - - 23
+    - 'Architecture Library: Reserve Closed'
+    - uesr
+    - '2015-06-02 16:39:42.843429'
+    - '2015-06-02 16:39:42.843429'
+    - 3
+    - false
+    - false
+    - false
+    - false
+    - false
+  - - 24
+    - 'Architecture Library: Reference'
+    - uesrf
+    - '2015-06-02 16:39:43.000152'
+    - '2015-06-02 16:39:43.000152'
+    - 3
+    - false
+    - false
+    - false
+    - false
+    - false
+  - - 25
+    - East Asian Library
+    - c
+    - '2015-06-02 16:39:43.134378'
+    - '2015-06-02 16:39:43.134378'
+    - 4
+    - false
+    - false
+    - true
+    - false
+    - false
+  - - 26
+    - 'East Asian Library: Rare Books'
+    - crare
+    - '2015-06-02 16:39:43.288452'
+    - '2015-06-02 16:39:43.288452'
+    - 4
+    - true
+    - false
+    - true
+    - false
+    - true
+  - - 27
+    - 'East Asian Library: Reference'
+    - cref
+    - '2015-06-02 16:39:43.444220'
+    - '2015-06-02 16:39:43.444220'
+    - 4
+    - false
+    - false
+    - true
+    - false
+    - false
+  - - 28
+    - 'East Asian Library: Western'
+    - gest
+    - '2015-06-02 16:39:43.578531'
+    - '2015-06-02 16:39:43.578531'
+    - 4
+    - false
+    - false
+    - true
+    - false
+    - false
+  - - 29
+    - 'East Asian Library: Western Periodicals'
+    - gestpe
+    - '2015-06-02 16:39:43.723709'
+    - '2015-06-02 16:39:43.723709'
+    - 4
+    - false
+    - false
+    - true
+    - false
+    - false
+  - - 30
+    - 'East Asian Library: Permanent Reserve'
+    - gestpr
+    - '2015-06-02 16:39:43.867998'
+    - '2015-06-02 16:39:43.867998'
+    - 4
+    - false
+    - false
+    - true
+    - false
+    - false
+  - - 31
+    - 'East Asian Library: Rare Books'
+    - gestrare
+    - '2015-06-02 16:39:44.023655'
+    - '2015-06-02 16:39:44.023655'
+    - 4
+    - true
+    - false
+    - true
+    - false
+    - true
+  - - 32
+    - 'East Asian Library: Reference'
+    - gestrf
+    - '2015-06-02 16:39:44.162469'
+    - '2015-06-02 16:39:44.162469'
+    - 4
+    - false
+    - false
+    - true
+    - false
+    - false
+  - - 33
+    - 'East Asian Library: Reserve'
+    - gstr
+    - '2015-06-02 16:39:44.312194'
+    - '2015-06-02 16:39:44.312194'
+    - 4
+    - false
+    - false
+    - true
+    - false
+    - false
+  - - 34
+    - 'East Asian Library: Reference'
+    - gstrf
+    - '2015-06-02 16:39:44.463197'
+    - '2015-06-02 16:39:44.463197'
+    - 4
+    - false
+    - false
+    - true
+    - false
+    - false
+  - - 35
+    - 'East Asian Library: East Asian Library (Gest)'
+    - hyc
+    - '2015-06-02 16:39:44.605157'
+    - '2015-06-02 16:39:44.605157'
+    - 4
+    - false
+    - false
+    - true
+    - false
+    - false
+  - - 36
+    - 'East Asian Library: Periodicals'
+    - hycpe
+    - '2015-06-02 16:39:44.749579'
+    - '2015-06-02 16:39:44.749579'
+    - 4
+    - false
+    - false
+    - true
+    - false
+    - false
+  - - 37
+    - 'East Asian Library: Rare Books'
+    - hycrare
+    - '2015-06-02 16:39:44.903662'
+    - '2015-06-02 16:39:44.903662'
+    - 4
+    - true
+    - false
+    - true
+    - false
+    - true
+  - - 38
+    - 'East Asian Library: Reference'
+    - hycrf
+    - '2015-06-02 16:39:45.056223'
+    - '2015-06-02 16:39:45.056223'
+    - 4
+    - false
+    - false
+    - true
+    - false
+    - false
+  - - 39
+    - East Asian Library
+    - hyg
+    - '2015-06-02 16:39:45.203090'
+    - '2015-06-02 16:39:45.203090'
+    - 4
+    - false
+    - false
+    - true
+    - false
+    - false
+  - - 40
+    - East Asian Library
+    - hyj
+    - '2015-06-02 16:39:45.344532'
+    - '2015-06-02 16:39:45.344532'
+    - 4
+    - false
+    - false
+    - true
+    - false
+    - false
+  - - 41
+    - East Asian Library
+    - hyjpe
+    - '2015-06-02 16:39:45.492752'
+    - '2015-06-02 16:39:45.492752'
+    - 4
+    - false
+    - false
+    - true
+    - false
+    - false
+  - - 42
+    - 'East Asian Library: Rare Books'
+    - hyjrare
+    - '2015-06-02 16:39:45.625024'
+    - '2015-06-02 16:39:45.625024'
+    - 4
+    - true
+    - false
+    - true
+    - false
+    - true
+  - - 43
+    - 'East Asian Library: Reference'
+    - hyjrf
+    - '2015-06-02 16:39:45.785196'
+    - '2015-06-02 16:39:45.785196'
+    - 4
+    - false
+    - false
+    - true
+    - false
+    - false
+  - - 44
+    - East Asian Library
+    - hyk
+    - '2015-06-02 16:39:45.955342'
+    - '2015-06-02 16:39:45.955342'
+    - 4
+    - false
+    - false
+    - true
+    - false
+    - false
+  - - 45
+    - 'East Asian Library: Rare Books'
+    - hykrare
+    - '2015-06-02 16:39:46.105208'
+    - '2015-06-02 16:39:46.105208'
+    - 4
+    - true
+    - false
+    - true
+    - false
+    - true
+  - - 46
+    - 'East Asian Library: Reference'
+    - hykrf
+    - '2015-06-02 16:39:46.271547'
+    - '2015-06-02 16:39:46.271547'
+    - 4
+    - false
+    - false
+    - true
+    - false
+    - false
+  - - 47
+    - East Asian Library
+    - j
+    - '2015-06-02 16:39:46.396623'
+    - '2015-06-02 16:39:46.396623'
+    - 4
+    - false
+    - false
+    - true
+    - false
+    - false
+  - - 48
+    - 'East Asian Library: Rare Books'
+    - jrare
+    - '2015-06-02 16:39:46.551192'
+    - '2015-06-02 16:39:46.551192'
+    - 4
+    - true
+    - false
+    - true
+    - false
+    - true
+  - - 49
+    - 'East Asian Library: Reference'
+    - jref
+    - '2015-06-02 16:39:46.671342'
+    - '2015-06-02 16:39:46.671342'
+    - 4
+    - false
+    - false
+    - true
+    - false
+    - false
+  - - 50
+    - East Asian Library
+    - k
+    - '2015-06-02 16:39:46.815128'
+    - '2015-06-02 16:39:46.815128'
+    - 4
+    - false
+    - false
+    - true
+    - false
+    - false
+  - - 51
+    - 'East Asian Library: Rare Books'
+    - krare
+    - '2015-06-02 16:39:46.974939'
+    - '2015-06-02 16:39:46.974939'
+    - 4
+    - true
+    - false
+    - true
+    - false
+    - true
+  - - 52
+    - 'East Asian Library: Reference'
+    - kref
+    - '2015-06-02 16:39:47.118215'
+    - '2015-06-02 16:39:47.118215'
+    - 4
+    - false
+    - false
+    - true
+    - false
+    - false
+  - - 53
+    - 'East Asian Library: Near East Department Collection (NED). Jones Hall'
+    - ned
+    - '2015-06-02 16:39:47.272140'
+    - '2015-06-02 16:39:47.272140'
+    - 4
+    - false
+    - false
+    - false
+    - true
+    - false
+  - - 54
+    - Engineering Library
+    - ast
+    - '2015-06-02 16:39:47.417691'
+    - '2015-06-02 16:39:47.417691'
+    - 5
+    - false
+    - false
+    - true
+    - false
+    - false
+  - - 55
+    - 'Engineering Library: Media Collection'
+    - astrf
+    - '2015-06-02 16:39:47.580419'
+    - '2015-06-02 16:39:47.580419'
+    - 5
+    - false
+    - false
+    - false
+    - false
+    - false
+  - - 56
+    - 'Engineering Library: Computer Media'
+    - ltopst
+    - '2015-06-02 16:39:47.723501'
+    - '2015-06-02 16:39:47.723501'
+    - 5
+    - false
+    - false
+    - false
+    - false
+    - false
+  - - 57
+    - 'Engineering Library: Friend Center Archive'
+    - scc
+    - '2015-06-02 16:39:47.881240'
+    - '2015-06-02 16:39:47.881240'
+    - 5
+    - false
+    - false
+    - false
+    - false
+    - false
+  - - 58
+    - Engineering Library
+    - st
+    - '2015-06-02 16:39:48.016355'
+    - '2015-06-02 16:39:48.016355'
+    - 5
+    - false
+    - false
+    - true
+    - false
+    - false
+  - - 59
+    - 'Engineering Library: Indexes and Abstracts'
+    - stia
+    - '2015-06-02 16:39:48.188229'
+    - '2015-06-02 16:39:48.188229'
+    - 5
+    - false
+    - false
+    - true
+    - false
+    - false
+  - - 60
+    - Engineering Library
+    - str
+    - '2015-06-02 16:39:48.355166'
+    - '2015-06-02 16:39:48.355166'
+    - 5
+    - false
+    - false
+    - true
+    - false
+    - false
+  - - 61
+    - 'Engineering Library: Reference'
+    - strf
+    - '2015-06-02 16:39:48.496719'
+    - '2015-06-02 16:39:48.496719'
+    - 5
+    - false
+    - false
+    - true
+    - false
+    - false
+  - - 62
+    - 'Engineering Library: Circulation Desk Reserve Collection'
+    - strp
+    - '2015-06-02 16:39:48.636048'
+    - '2015-06-02 16:39:48.636048'
+    - 5
+    - false
+    - false
+    - false
+    - false
+    - false
+  - - 63
+    - 'Engineering Library: Reserve'
+    - strr
+    - '2015-06-02 16:39:48.761462'
+    - '2015-06-02 16:39:48.761462'
+    - 5
+    - false
+    - false
+    - false
+    - false
+    - false
+  - - 64
+    - 'Engineering Library: Serials'
+    - stss
+    - '2015-06-02 16:39:48.916127'
+    - '2015-06-02 16:39:48.916127'
+    - 5
+    - false
+    - false
+    - true
+    - false
+    - false
+  - - 65
+    - 'Engineering Library: Theses'
+    - stt
+    - '2015-06-02 16:39:49.047830'
+    - '2015-06-02 16:39:49.047830'
+    - 5
+    - false
+    - false
+    - true
+    - false
+    - false
+  - - 66
+    - 'Firestone Library: African-American Studies Collection '
+    - aas
+    - '2015-06-02 16:39:49.202321'
+    - '2015-06-02 16:39:49.202321'
+    - 6
+    - false
+    - false
+    - true
+    - false
+    - false
+  - - 67
+    - 'Firestone Library: Classics Collection'
+    - clas
+    - '2015-06-02 16:39:49.327463'
+    - '2015-06-02 16:39:49.327463'
+    - 6
+    - false
+    - false
+    - true
+    - false
+    - false
+  - - 68
+    - 'Firestone Library: Classics Non Circulating'
+    - clasnc
+    - '2015-06-02 16:39:49.482263'
+    - '2015-06-02 16:39:49.482263'
+    - 6
+    - false
+    - false
+    - true
+    - false
+    - false
+  - - 69
+    - 'Firestone Library: Cataloging and Metadata Services'
+    - dc
+    - '2015-06-02 16:39:49.609614'
+    - '2015-06-02 16:39:49.609614'
+    - 6
+    - false
+    - false
+    - false
+    - false
+    - false
+  - - 70
+    - 'Firestone Library: Dixon Books'
+    - dixn
+    - '2015-06-02 16:39:49.764754'
+    - '2015-06-02 16:39:49.764754'
+    - 6
+    - false
+    - false
+    - true
+    - false
+    - false
+  - - 71
+    - 'Firestone Library: Government Documents Collection '
+    - docs
+    - '2015-06-02 16:39:49.895564'
+    - '2015-06-02 16:39:49.895564'
+    - 6
+    - false
+    - false
+    - true
+    - false
+    - false
+  - - 72
+    - 'Firestone Library: Government Documents Collection: Microforms'
+    - docsm
+    - '2015-06-02 16:39:50.039529'
+    - '2015-06-02 16:39:50.039529'
+    - 6
+    - false
+    - false
+    - false
+    - false
+    - false
+  - - 73
+    - 'Firestone Library: Trustee Reading Room Reference'
+    - dr
+    - '2015-06-02 16:39:50.186123'
+    - '2015-06-02 16:39:50.186123'
+    - 6
+    - false
+    - false
+    - false
+    - false
+    - false
+  - - 74
+    - 'Firestone Library: Trustee Reading Room Reference: Atlases'
+    - dra
+    - '2015-06-02 16:39:50.346743'
+    - '2015-06-02 16:39:50.346743'
+    - 6
+    - false
+    - false
+    - false
+    - false
+    - false
+  - - 75
+    - 'Firestone Library: Trustee Reading Room Reference: Ready Reference'
+    - drrr
+    - '2015-06-02 16:39:50.496254'
+    - '2015-06-02 16:39:50.496254'
+    - 6
+    - false
+    - false
+    - false
+    - false
+    - false
+  - - 76
+    - 'Firestone Library: Data and Statistical Services '
+    - dss
+    - '2015-06-02 16:39:50.630424'
+    - '2015-06-02 16:39:50.630424'
+    - 6
+    - false
+    - false
+    - false
+    - false
+    - false
+  - - 77
+    - 'Firestone Library: English Graduate Study Room'
+    - egsr
+    - '2015-06-02 16:39:50.780316'
+    - '2015-06-02 16:39:50.780316'
+    - 6
+    - false
+    - false
+    - false
+    - false
+    - false
+  - - 78
+    - Firestone Library
+    - f
+    - '2015-06-02 16:39:50.913311'
+    - '2015-06-02 16:39:50.913311'
+    - 6
+    - false
+    - false
+    - true
+    - false
+    - false
+  - - 79
+    - 'Firestone Library: French & Italian Grad Study Rm/Sem'
+    - fis
+    - '2015-06-02 16:39:51.054007'
+    - '2015-06-02 16:39:51.054007'
+    - 6
+    - false
+    - false
+    - false
+    - false
+    - false
+  - - 80
+    - 'Firestone Library: Microforms Services'
+    - flm
+    - '2015-06-02 16:39:51.205832'
+    - '2015-06-02 16:39:51.205832'
+    - 6
+    - false
+    - false
+    - false
+    - false
+    - false
+  - - 81
+    - 'Firestone Library: Microforms Services'
+    - flmb
+    - '2015-06-02 16:39:51.372411'
+    - '2015-06-02 16:39:51.372411'
+    - 6
+    - false
+    - false
+    - false
+    - false
+    - false
+  - - 82
+    - 'Firestone Library: Microforms Services'
+    - flmm
+    - '2015-06-02 16:39:51.510869'
+    - '2015-06-02 16:39:51.510869'
+    - 6
+    - false
+    - false
+    - false
+    - false
+    - false
+  - - 83
+    - 'Firestone Library: Microforms Services'
+    - flmp
+    - '2015-06-02 16:39:51.633420'
+    - '2015-06-02 16:39:51.633420'
+    - 6
+    - false
+    - false
+    - false
+    - false
+    - false
+  - - 84
+    - 'Firestone Library: Non Circulating'
+    - fnc
+    - '2015-06-02 16:39:51.760506'
+    - '2015-06-02 16:39:51.760506'
+    - 6
+    - false
+    - false
+    - true
+    - false
+    - false
+  - - 85
+    - 'Firestone Library: Microforms Services: East Asian'
+    - gestf
+    - '2015-06-02 16:39:51.902132'
+    - '2015-06-02 16:39:51.902132'
+    - 6
+    - false
+    - false
+    - true
+    - false
+    - false
+  - - 86
+    - 'Firestone Library: Miriam Y. Holden Collection'
+    - hldn
+    - '2015-06-02 16:39:52.033832'
+    - '2015-06-02 16:39:52.033832'
+    - 6
+    - false
+    - false
+    - false
+    - false
+    - false
+  - - 87
+    - 'Forrestal Annex: Forrestal Annex - Microforms Services: East Asian'
+    - hygf
+    - '2015-06-02 16:39:52.202845'
+    - '2015-06-02 16:39:52.202845'
+    - 1
+    - false
+    - false
+    - false
+    - true
+    - false
+  - - 88
+    - 'Firestone Library: Law Cases and Statutes '
+    - law
+    - '2015-06-02 16:39:52.368726'
+    - '2015-06-02 16:39:52.368726'
+    - 6
+    - false
+    - false
+    - false
+    - false
+    - false
+  - - 89
+    - 'Firestone Library: Computer Media'
+    - ltop
+    - '2015-06-02 16:39:52.512385'
+    - '2015-06-02 16:39:52.512385'
+    - 6
+    - false
+    - false
+    - false
+    - false
+    - false
+  - - 90
+    - 'Firestone Library: Near East Collections'
+    - nec
+    - '2015-06-02 16:39:52.654216'
+    - '2015-06-02 16:39:52.654216'
+    - 6
+    - false
+    - false
+    - true
+    - false
+    - false
+  - - 91
+    - 'Firestone Library: Near East Collections Non Circulating'
+    - necnc
+    - '2015-06-02 16:39:52.797207'
+    - '2015-06-02 16:39:52.797207'
+    - 6
+    - false
+    - false
+    - true
+    - false
+    - false
+  - - 92
+    - 'Firestone Library: New Order Request'
+    - new
+    - '2015-06-02 16:39:52.958607'
+    - '2015-06-02 16:39:52.958607'
+    - 6
+    - false
+    - false
+    - false
+    - true
+    - false
+  - - 93
+    - 'Firestone Library: Newspaper Collection: Recent Issues. '
+    - nr
+    - '2015-06-02 16:39:53.132773'
+    - '2015-06-02 16:39:53.132773'
+    - 6
+    - false
+    - false
+    - false
+    - false
+    - false
+  - - 94
+    - 'Firestone Library: Periodicals Reading Room'
+    - pr
+    - '2015-06-02 16:39:53.263658'
+    - '2015-06-02 16:39:53.263658'
+    - 6
+    - false
+    - false
+    - false
+    - false
+    - false
+  - - 95
+    - 'Firestone Library: Periodicals Reading Room: Near East Periodicals'
+    - prne
+    - '2015-06-02 16:39:53.404263'
+    - '2015-06-02 16:39:53.404263'
+    - 6
+    - false
+    - false
+    - false
+    - false
+    - false
+  - - 96
+    - 'Firestone Library: 3 Hour Reserve '
+    - resc
+    - '2015-06-02 16:39:53.570437'
+    - '2015-06-02 16:39:53.570437'
+    - 6
+    - false
+    - false
+    - false
+    - false
+    - false
+  - - 97
+    - 'Firestone Library: 24 Hour Reserve '
+    - reso
+    - '2015-06-02 16:39:53.712798'
+    - '2015-06-02 16:39:53.712798'
+    - 6
+    - false
+    - false
+    - false
+    - false
+    - false
+  - - 98
+    - 'Firestone Library: Religion Graduate Study: Reserve'
+    - rrel
+    - '2015-06-02 16:39:53.869136'
+    - '2015-06-02 16:39:53.869136'
+    - 6
+    - false
+    - false
+    - false
+    - false
+    - false
+  - - 99
+    - 'Firestone Library: Classics Graduate Study: Reserve'
+    - rsc
+    - '2015-06-02 16:39:54.002957'
+    - '2015-06-02 16:39:54.002957'
+    - 6
+    - false
+    - false
+    - false
+    - false
+    - false
+  - - 100
+    - 'Firestone Library: Germanic Languages Graduate Study Room: Reserve'
+    - rsd
+    - '2015-06-02 16:39:54.157849'
+    - '2015-06-02 16:39:54.157849'
+    - 6
+    - false
+    - false
+    - false
+    - false
+    - false
+  - - 101
+    - 'Firestone Library: English Graduate Study Room: Reserve'
+    - rse
+    - '2015-06-02 16:39:54.324426'
+    - '2015-06-02 16:39:54.324426'
+    - 6
+    - false
+    - false
+    - false
+    - false
+    - false
+  - - 102
+    - 'Firestone Library: History Reference: Reserve'
+    - rsh
+    - '2015-06-02 16:39:54.467242'
+    - '2015-06-02 16:39:54.467242'
+    - 6
+    - false
+    - false
+    - false
+    - false
+    - false
+  - - 103
+    - 'Firestone Library: Politics Graduate Study Room: Reserve'
+    - rshp
+    - '2015-06-02 16:39:54.607349'
+    - '2015-06-02 16:39:54.607349'
+    - 6
+    - false
+    - false
+    - false
+    - false
+    - false
+  - - 104
+    - 'Firestone Library: Russian Studies Reading Rom: Reserve'
+    - rslv
+    - '2015-06-02 16:39:54.771514'
+    - '2015-06-02 16:39:54.771514'
+    - 6
+    - false
+    - false
+    - false
+    - false
+    - false
+  - - 105
+    - 'Firestone Library: Near East Graduate Study Room: Reserve'
+    - rsne
+    - '2015-06-02 16:39:54.908613'
+    - '2015-06-02 16:39:54.908613'
+    - 6
+    - false
+    - false
+    - false
+    - false
+    - false
+  - - 106
+    - 'Firestone Library: Anthropology Graduate Study Room: Reserve'
+    - rsnst
+    - '2015-06-02 16:39:55.059667'
+    - '2015-06-02 16:39:55.059667'
+    - 6
+    - false
+    - false
+    - false
+    - false
+    - false
+  - - 107
+    - 'Firestone Library: Philosophy Graduate Study Room: Reserve'
+    - rsp
+    - '2015-06-02 16:39:55.237952'
+    - '2015-06-02 16:39:55.237952'
+    - 6
+    - false
+    - false
+    - false
+    - false
+    - false
+  - - 108
+    - 'Firestone Library: Comparative Literature Graduate Study Room: Reserve'
+    - rspc
+    - '2015-06-02 16:39:55.389054'
+    - '2015-06-02 16:39:55.389054'
+    - 6
+    - false
+    - false
+    - false
+    - false
+    - false
+  - - 109
+    - 'Firestone Library: Sociology Graduate Study Room: Reserve'
+    - rssa
+    - '2015-06-02 16:39:55.540364'
+    - '2015-06-02 16:39:55.540364'
+    - 6
+    - false
+    - false
+    - false
+    - false
+    - false
+  - - 110
+    - 'Firestone Library: Economics Graduate Study Room: Reserve'
+    - rsx
+    - '2015-06-02 16:39:55.687648'
+    - '2015-06-02 16:39:55.687648'
+    - 6
+    - false
+    - false
+    - false
+    - false
+    - false
+  - - 111
+    - 'Firestone Library: Classics Graduate Study'
+    - sc
+    - '2015-06-02 16:39:55.858235'
+    - '2015-06-02 16:39:55.858235'
+    - 6
+    - false
+    - false
+    - false
+    - false
+    - false
+  - - 112
+    - 'Firestone Library: Germanic Languages Graduate Study Room'
+    - sd
+    - '2015-06-02 16:39:56.024209'
+    - '2015-06-02 16:39:56.024209'
+    - 6
+    - false
+    - false
+    - false
+    - false
+    - false
+  - - 113
+    - 'Firestone Library: Scribner Room '
+    - se
+    - '2015-06-02 16:39:56.152418'
+    - '2015-06-02 16:39:56.152418'
+    - 6
+    - false
+    - false
+    - false
+    - false
+    - false
+  - - 114
+    - 'Firestone Library: Scribner Room: Reference'
+    - seref
+    - '2015-06-02 16:39:56.312416'
+    - '2015-06-02 16:39:56.312416'
+    - 6
+    - false
+    - false
+    - false
+    - false
+    - false
+  - - 115
+    - 'Firestone Library: History Reference'
+    - sh
+    - '2015-06-02 16:39:56.475209'
+    - '2015-06-02 16:39:56.475209'
+    - 6
+    - false
+    - false
+    - false
+    - false
+    - false
+  - - 116
+    - 'Firestone Library: Politics Graduate Study Room'
+    - shp
+    - '2015-06-02 16:39:56.637616'
+    - '2015-06-02 16:39:56.637616'
+    - 6
+    - false
+    - false
+    - false
+    - false
+    - false
+  - - 117
+    - 'Firestone Library: Hellenic Studies Reading Room'
+    - shs
+    - '2015-06-02 16:39:56.807682'
+    - '2015-06-02 16:39:56.807682'
+    - 6
+    - false
+    - false
+    - false
+    - false
+    - false
+  - - 118
+    - 'Firestone Library: Russian Studies Reading Room'
+    - slav
+    - '2015-06-02 16:39:56.956135'
+    - '2015-06-02 16:39:56.956135'
+    - 6
+    - false
+    - false
+    - false
+    - false
+    - false
+  - - 119
+    - 'Firestone Library: Near East Graduate Study Room'
+    - sne
+    - '2015-06-02 16:39:57.107850'
+    - '2015-06-02 16:39:57.107850'
+    - 6
+    - false
+    - false
+    - false
+    - false
+    - false
+  - - 120
+    - 'Firestone Library: Philosophy Graduate Study Room'
+    - sp
+    - '2015-06-02 16:39:57.266148'
+    - '2015-06-02 16:39:57.266148'
+    - 6
+    - false
+    - false
+    - false
+    - false
+    - false
+  - - 121
+    - 'Firestone Library: Comparative Literature Graduate Study Room'
+    - spc
+    - '2015-06-02 16:39:57.410670'
+    - '2015-06-02 16:39:57.410670'
+    - 6
+    - false
+    - false
+    - false
+    - false
+    - false
+  - - 122
+    - 'Firestone Library: Comparative Literature Graduate Study Room'
+    - spl
+    - '2015-06-02 16:39:57.551620'
+    - '2015-06-02 16:39:57.551620'
+    - 6
+    - false
+    - false
+    - false
+    - false
+    - false
+  - - 123
+    - 'Firestone Library: Spanish & Portuguese Grad Study Room'
+    - sps
+    - '2015-06-02 16:39:57.732590'
+    - '2015-06-02 16:39:57.732590'
+    - 6
+    - false
+    - false
+    - false
+    - false
+    - false
+  - - 124
+    - 'Firestone Library: Religion Graduate Study'
+    - srel
+    - '2015-06-02 16:39:57.894600'
+    - '2015-06-02 16:39:57.894600'
+    - 6
+    - false
+    - false
+    - false
+    - false
+    - false
+  - - 125
+    - 'Firestone Library: Sociology Graduate Study Room'
+    - ssa
+    - '2015-06-02 16:39:58.056754'
+    - '2015-06-02 16:39:58.056754'
+    - 6
+    - false
+    - false
+    - false
+    - false
+    - false
+  - - 126
+    - 'Firestone Library: Social Science Reference Center'
+    - ssrc
+    - '2015-06-02 16:39:58.226182'
+    - '2015-06-02 16:39:58.226182'
+    - 6
+    - false
+    - false
+    - false
+    - false
+    - false
+  - - 127
+    - 'Firestone Library: Data and Statisticsal Services: Decennial Census'
+    - ssrcdc
+    - '2015-06-02 16:39:58.383454'
+    - '2015-06-02 16:39:58.383454'
+    - 6
+    - false
+    - false
+    - false
+    - false
+    - false
+  - - 128
+    - 'Firestone Library: Data and Statisticsal Services: Foreign Stat. Abs.'
+    - ssrcfo
+    - '2015-06-02 16:39:58.551195'
+    - '2015-06-02 16:39:58.551195'
+    - 6
+    - false
+    - false
+    - false
+    - false
+    - false
+  - - 129
+    - 'Firestone Library: Social Science Reference Center: Ready Reference'
+    - ssrcrr
+    - '2015-06-02 16:39:58.728213'
+    - '2015-06-02 16:39:58.728213'
+    - 6
+    - false
+    - false
+    - false
+    - false
+    - false
+  - - 130
+    - 'Firestone Library: History Graduate Study'
+    - sss
+    - '2015-06-02 16:39:58.872571'
+    - '2015-06-02 16:39:58.872571'
+    - 6
+    - false
+    - false
+    - false
+    - false
+    - false
+  - - 131
+    - 'Firestone Library: Economics Graduate Study Room'
+    - sx
+    - '2015-06-02 16:39:59.043097'
+    - '2015-06-02 16:39:59.043097'
+    - 6
+    - false
+    - false
+    - false
+    - false
+    - false
+  - - 132
+    - 'Firestone Library: Social Science Reference Center: Index Tables. '
+    - sxfa
+    - '2015-06-02 16:39:59.185219'
+    - '2015-06-02 16:39:59.185219'
+    - 6
+    - false
+    - false
+    - false
+    - false
+    - false
+  - - 133
+    - 'Firestone Library: Pliny Fisk Library: Financial Serv. '
+    - sxffi
+    - '2015-06-02 16:39:59.363403'
+    - '2015-06-02 16:39:59.363403'
+    - 6
+    - false
+    - false
+    - false
+    - false
+    - false
+  - - 134
+    - 'Firestone Library: Pliny Fisk Library: Federal Reserve. '
+    - sxffr
+    - '2015-06-02 16:39:59.521646'
+    - '2015-06-02 16:39:59.521646'
+    - 6
+    - false
+    - false
+    - false
+    - false
+    - false
+  - - 135
+    - 'Firestone Library: Pliny Fisk Library: Index Tables'
+    - sxfit
+    - '2015-06-02 16:39:59.674869'
+    - '2015-06-02 16:39:59.674869'
+    - 6
+    - false
+    - false
+    - false
+    - false
+    - false
+  - - 136
+    - 'Firestone Library: Pliny Fisk Library: Ready Reference.'
+    - sxfrr
+    - '2015-06-02 16:39:59.846794'
+    - '2015-06-02 16:39:59.846794'
+    - 6
+    - false
+    - false
+    - false
+    - false
+    - false
+  - - 137
+    - 'Firestone Library: United Nations Collection'
+    - un
+    - '2015-06-02 16:40:00.018800'
+    - '2015-06-02 16:40:00.018800'
+    - 6
+    - false
+    - false
+    - false
+    - false
+    - false
+  - - 138
+    - 'Firestone Library: Very large books'
+    - xl
+    - '2015-06-02 16:40:00.169928'
+    - '2015-06-02 16:40:00.169928'
+    - 6
+    - false
+    - false
+    - true
+    - false
+    - false
+  - - 139
+    - 'Firestone Library: Very large books Non Circulating'
+    - xlnc
+    - '2015-06-02 16:40:00.315334'
+    - '2015-06-02 16:40:00.315334'
+    - 6
+    - false
+    - false
+    - true
+    - false
+    - false
+  - - 140
+    - 'Firestone Library: Zeiss Wildlife Collection'
+    - zeis
+    - '2015-06-02 16:40:00.487356'
+    - '2015-06-02 16:40:00.487356'
+    - 6
+    - false
+    - false
+    - true
+    - false
+    - false
+  - - 141
+    - 'Humanities Resource Center: Video Collection'
+    - lrc
+    - '2015-06-02 16:40:00.634797'
+    - '2015-06-02 16:40:00.634797'
+    - 7
+    - false
+    - false
+    - false
+    - false
+    - false
+  - - 142
+    - 'Humanities Resource Center: Permanent Reserve'
+    - lrcpt
+    - '2015-06-02 16:40:00.794120'
+    - '2015-06-02 16:40:00.794120'
+    - 7
+    - false
+    - false
+    - false
+    - false
+    - false
+  - - 143
+    - 'Humanities Resource Center: Reserve'
+    - lrcr
+    - '2015-06-02 16:40:00.943956'
+    - '2015-06-02 16:40:00.943956'
+    - 7
+    - false
+    - false
+    - false
+    - false
+    - false
+  - - 144
+    - 'Humanities Resource Center: Video Collection'
+    - vidl
+    - '2015-06-02 16:40:01.098070'
+    - '2015-06-02 16:40:01.098070'
+    - 7
+    - false
+    - false
+    - false
+    - false
+    - false
+  - - 145
+    - 'Humanities Resource Center: Reserve'
+    - vidlr
+    - '2015-06-02 16:40:01.243319'
+    - '2015-06-02 16:40:01.243319'
+    - 7
+    - false
+    - false
+    - false
+    - false
+    - false
+  - - 146
+    - 'Lewis Library: Computer Media'
+    - ltopsci
+    - '2015-06-02 16:40:01.407468'
+    - '2015-06-02 16:40:01.407468'
+    - 8
+    - false
+    - false
+    - false
+    - false
+    - false
+  - - 147
+    - Lewis Library
+    - sci
+    - '2015-06-02 16:40:01.562547'
+    - '2015-06-02 16:40:01.562547'
+    - 8
+    - false
+    - false
+    - true
+    - false
+    - false
+  - - 148
+    - 'Lewis Library: Documents'
+    - scidoc
+    - '2015-06-02 16:40:01.717745'
+    - '2015-06-02 16:40:01.717745'
+    - 8
+    - false
+    - false
+    - false
+    - false
+    - false
+  - - 149
+    - 'Lewis Library: E/F Oversize and Atlases'
+    - sciefa
+    - '2015-06-02 16:40:01.863279'
+    - '2015-06-02 16:40:01.863279'
+    - 8
+    - false
+    - false
+    - true
+    - false
+    - false
+  - - 150
+    - 'Lewis Library: GIS and Digital Map Center'
+    - scigis
+    - '2015-06-02 16:40:02.016817'
+    - '2015-06-02 16:40:02.016817'
+    - 8
+    - false
+    - false
+    - false
+    - false
+    - false
+  - - 151
+    - 'Lewis Library: Graduate Reading'
+    - scigr
+    - '2015-06-02 16:40:02.165339'
+    - '2015-06-02 16:40:02.165339'
+    - 8
+    - false
+    - false
+    - false
+    - false
+    - false
+  - - 152
+    - 'Lewis Library: Limited Access (Fine Hall Wing A-Floor)'
+    - scilaf
+    - '2015-06-02 16:40:02.356222'
+    - '2015-06-02 16:40:02.356222'
+    - 8
+    - false
+    - false
+    - false
+    - true
+    - false
+  - - 153
+    - 'Lewis Library: Limited Access'
+    - scilal
+    - '2015-06-02 16:40:02.533097'
+    - '2015-06-02 16:40:02.533097'
+    - 8
+    - false
+    - false
+    - false
+    - false
+    - false
+  - - 154
+    - 'Lewis Library: Map Collection'
+    - scimap
+    - '2015-06-02 16:40:02.666278'
+    - '2015-06-02 16:40:02.666278'
+    - 8
+    - false
+    - false
+    - false
+    - false
+    - false
+  - - 155
+    - 'Lewis Library: Map Collection. Map Case'
+    - scimc
+    - '2015-06-02 16:40:02.815293'
+    - '2015-06-02 16:40:02.815293'
+    - 8
+    - false
+    - false
+    - false
+    - false
+    - false
+  - - 156
+    - 'Lewis Library: Map Collection. Map Case Max'
+    - scimcm
+    - '2015-06-02 16:40:02.960451'
+    - '2015-06-02 16:40:02.960451'
+    - 8
+    - false
+    - false
+    - false
+    - false
+    - false
+  - - 157
+    - 'Lewis Library: Microforms'
+    - scimic
+    - '2015-06-02 16:40:03.110252'
+    - '2015-06-02 16:40:03.110252'
+    - 8
+    - false
+    - false
+    - false
+    - false
+    - false
+  - - 158
+    - 'Lewis Library: Map Collection. Lateral File'
+    - sciml
+    - '2015-06-02 16:40:03.242652'
+    - '2015-06-02 16:40:03.242652'
+    - 8
+    - false
+    - false
+    - false
+    - false
+    - false
+  - - 159
+    - 'Lewis Library: Map Collection. Reference Maps'
+    - scimlrf
+    - '2015-06-02 16:40:03.380955'
+    - '2015-06-02 16:40:03.380955'
+    - 8
+    - false
+    - false
+    - false
+    - false
+    - false
+  - - 160
+    - 'Lewis Library: Multimedia'
+    - scimm
+    - '2015-06-02 16:40:03.536663'
+    - '2015-06-02 16:40:03.536663'
+    - 8
+    - false
+    - false
+    - false
+    - false
+    - false
+  - - 161
+    - 'Lewis Library: Pamphlet'
+    - scipam
+    - '2015-06-02 16:40:03.673590'
+    - '2015-06-02 16:40:03.673590'
+    - 8
+    - false
+    - false
+    - false
+    - false
+    - false
+  - - 162
+    - 'Lewis Library: Peyton Hall Observing Room'
+    - sciph
+    - '2015-06-02 16:40:03.834718'
+    - '2015-06-02 16:40:03.834718'
+    - 8
+    - false
+    - false
+    - false
+    - false
+    - false
+  - - 163
+    - 'Lewis Library: Reference (Fine Hall Wing)'
+    - sciref
+    - '2015-06-02 16:40:03.985896'
+    - '2015-06-02 16:40:03.985896'
+    - 8
+    - false
+    - false
+    - false
+    - false
+    - false
+  - - 164
+    - 'Lewis Library: Reference (Information Desk)'
+    - scirefl
+    - '2015-06-02 16:40:04.132900'
+    - '2015-06-02 16:40:04.132900'
+    - 8
+    - false
+    - false
+    - false
+    - false
+    - false
+  - - 165
+    - 'Lewis Library: Course Reserve'
+    - scires
+    - '2015-06-02 16:40:04.335250'
+    - '2015-06-02 16:40:04.335250'
+    - 8
+    - false
+    - false
+    - false
+    - false
+    - false
+  - - 166
+    - 'Lewis Library: Term Loan Reserves'
+    - sciresp
+    - '2015-06-02 16:40:04.486498'
+    - '2015-06-02 16:40:04.486498'
+    - 8
+    - false
+    - false
+    - false
+    - true
+    - false
+  - - 167
+    - 'Lewis Library: SuDoc Collection.'
+    - scisd
+    - '2015-06-02 16:40:04.639980'
+    - '2015-06-02 16:40:04.639980'
+    - 8
+    - false
+    - false
+    - false
+    - false
+    - false
+  - - 168
+    - 'Lewis Library: Serials (shelved by serial title)'
+    - sciss
+    - '2015-06-02 16:40:04.813314'
+    - '2015-06-02 16:40:04.813314'
+    - 8
+    - false
+    - false
+    - false
+    - false
+    - false
+  - - 169
+    - 'Lewis Library: Theses'
+    - scith
+    - '2015-06-02 16:40:04.945748'
+    - '2015-06-02 16:40:04.945748'
+    - 8
+    - false
+    - false
+    - false
+    - false
+    - false
+  - - 170
+    - 'Marquand Library: Computer Media'
+    - ltopsa
+    - '2015-06-02 16:40:05.087753'
+    - '2015-06-02 16:40:05.087753'
+    - 9
+    - false
+    - false
+    - false
+    - false
+    - false
+  - - 171
+    - Marquand Library
+    - sa
+    - '2015-06-02 16:40:05.246468'
+    - '2015-06-02 16:40:05.246468'
+    - 9
+    - false
+    - false
+    - false
+    - false
+    - true
+  - - 172
+    - 'Marquand Library: Barr Ferree Collection'
+    - saf
+    - '2015-06-02 16:40:05.420369'
+    - '2015-06-02 16:40:05.420369'
+    - 9
+    - false
+    - false
+    - false
+    - false
+    - false
+  - - 173
+    - 'Marquand Library: Tang Reading Room'
+    - safesrf
+    - '2015-06-02 16:40:05.595113'
+    - '2015-06-02 16:40:05.595113'
+    - 9
+    - false
+    - false
+    - false
+    - false
+    - true
+  - - 174
+    - 'Marquand Library: Microforms'
+    - safi
+    - '2015-06-02 16:40:05.739440'
+    - '2015-06-02 16:40:05.739440'
+    - 9
+    - false
+    - false
+    - false
+    - false
+    - true
+  - - 175
+    - 'Marquand Library: Manuscripts'
+    - sams
+    - '2015-06-02 16:40:05.881543'
+    - '2015-06-02 16:40:05.881543'
+    - 9
+    - false
+    - false
+    - false
+    - false
+    - false
+  - - 176
+    - 'Marquand Library: Manuscripts: Reference'
+    - samsrf
+    - '2015-06-02 16:40:06.052539'
+    - '2015-06-02 16:40:06.052539'
+    - 9
+    - false
+    - false
+    - false
+    - false
+    - false
+  - - 177
+    - 'Marquand Library: Photography'
+    - saph
+    - '2015-06-02 16:40:06.221840'
+    - '2015-06-02 16:40:06.221840'
+    - 9
+    - false
+    - false
+    - false
+    - false
+    - true
+  - - 178
+    - 'Marquand Library: Photography Reference'
+    - saphrf
+    - '2015-06-02 16:40:06.375076'
+    - '2015-06-02 16:40:06.375076'
+    - 9
+    - false
+    - false
+    - false
+    - false
+    - false
+  - - 179
+    - 'Marquand Library: Reserve'
+    - sar
+    - '2015-06-02 16:40:06.540423'
+    - '2015-06-02 16:40:06.540423'
+    - 9
+    - false
+    - false
+    - false
+    - false
+    - false
+  - - 180
+    - 'Marquand Library: Reference'
+    - sarf
+    - '2015-06-02 16:40:06.697877'
+    - '2015-06-02 16:40:06.697877'
+    - 9
+    - false
+    - false
+    - false
+    - false
+    - true
+  - - 181
+    - 'Marquand Library: Storage'
+    - sarp
+    - '2015-06-02 16:40:06.866557'
+    - '2015-06-02 16:40:06.866557'
+    - 9
+    - false
+    - false
+    - false
+    - true
+    - false
+  - - 182
+    - 'Marquand Library: Rare Books: Miscellanea'
+    - sat
+    - '2015-06-02 16:40:07.030246'
+    - '2015-06-02 16:40:07.030246'
+    - 9
+    - true
+    - false
+    - false
+    - true
+    - true
+  - - 183
+    - 'Marquand Library: Workroom'
+    - sawr
+    - '2015-06-02 16:40:07.166233'
+    - '2015-06-02 16:40:07.166233'
+    - 9
+    - false
+    - false
+    - false
+    - false
+    - false
+  - - 184
+    - 'Marquand Library: Rare Books'
+    - sax
+    - '2015-06-02 16:40:07.330966'
+    - '2015-06-02 16:40:07.330966'
+    - 9
+    - true
+    - false
+    - false
+    - false
+    - true
+  - - 185
+    - Mudd Manuscript Library
+    - mudd
+    - '2015-06-02 16:40:07.485611'
+    - '2015-06-02 16:40:07.485611'
+    - 10
+    - true
+    - false
+    - false
+    - false
+    - true
+  - - 186
+    - 'Mudd Manuscript Library: Microforms'
+    - mudf
+    - '2015-06-02 16:40:07.636885'
+    - '2015-06-02 16:40:07.636885'
+    - 10
+    - true
+    - false
+    - false
+    - false
+    - true
+  - - 187
+    - 'Mudd Manuscript Library: Princetoniana Collection'
+    - prnc
+    - '2015-06-02 16:40:07.792362'
+    - '2015-06-02 16:40:07.792362'
+    - 10
+    - true
+    - false
+    - false
+    - false
+    - true
+  - - 188
+    - 'Mendel Music Library: Audio Visual (Circulation Desk)'
+    - mlis
+    - '2015-06-02 16:40:07.957668'
+    - '2015-06-02 16:40:07.957668'
+    - 11
+    - false
+    - false
+    - false
+    - true
+    - false
+  - - 189
+    - Mendel Music Library
+    - mus
+    - '2015-06-02 16:40:08.132309'
+    - '2015-06-02 16:40:08.132309'
+    - 11
+    - false
+    - false
+    - true
+    - false
+    - false
+  - - 190
+    - 'Mendel Music Library: Graduate Reserve'
+    - musg
+    - '2015-06-02 16:40:08.260103'
+    - '2015-06-02 16:40:08.260103'
+    - 11
+    - false
+    - false
+    - false
+    - false
+    - false
+  - - 191
+    - 'Mendel Music Library: Bound Periodicals'
+    - muspe
+    - '2015-06-02 16:40:08.401472'
+    - '2015-06-02 16:40:08.401472'
+    - 11
+    - false
+    - false
+    - false
+    - false
+    - false
+  - - 192
+    - 'Mendel Music Library: Reserve'
+    - musr
+    - '2015-06-02 16:40:08.513525'
+    - '2015-06-02 16:40:08.513525'
+    - 11
+    - false
+    - false
+    - false
+    - false
+    - false
+  - - 193
+    - 'Mendel Music Library: Reading Room (2nd Floor)'
+    - musrg
+    - '2015-06-02 16:40:08.669104'
+    - '2015-06-02 16:40:08.669104'
+    - 11
+    - false
+    - false
+    - true
+    - false
+    - false
+  - - 194
+    - 'Mendel Music Library: Reference'
+    - sv
+    - '2015-06-02 16:40:08.822835'
+    - '2015-06-02 16:40:08.822835'
+    - 11
+    - false
+    - false
+    - false
+    - false
+    - false
+  - - 195
+    - 'Mendel Music Library: Facsimiles'
+    - svf
+    - '2015-06-02 16:40:08.980771'
+    - '2015-06-02 16:40:08.980771'
+    - 11
+    - false
+    - false
+    - false
+    - false
+    - false
+  - - 196
+    - 'Mendel Music Library: Locked'
+    - svl
+    - '2015-06-02 16:40:09.105421'
+    - '2015-06-02 16:40:09.105421'
+    - 11
+    - false
+    - false
+    - false
+    - true
+    - false
+  - - 197
+    - 'Online: Online Resources'
+    - elf
+    - '2015-06-02 16:40:09.259305'
+    - '2015-06-02 16:40:09.259305'
+    - 12
+    - false
+    - false
+    - false
+    - false
+    - false
+  - - 198
+    - 'Online: *ONLINE*'
+    - elf1
+    - '2015-06-02 16:40:09.397315'
+    - '2015-06-02 16:40:09.397315'
+    - 12
+    - false
+    - false
+    - false
+    - false
+    - false
+  - - 199
+    - 'Online: Accessible from Library Web Computers'
+    - elf2
+    - '2015-06-02 16:40:09.534987'
+    - '2015-06-02 16:40:09.534987'
+    - 12
+    - false
+    - false
+    - false
+    - false
+    - false
+  - - 200
+    - 'Online: Online Resources'
+    - elf3
+    - '2015-06-02 16:40:09.673141'
+    - '2015-06-02 16:40:09.673141'
+    - 12
+    - false
+    - false
+    - false
+    - false
+    - false
+  - - 201
+    - 'Online: Dixon eBooks'
+    - elf4
+    - '2015-06-02 16:40:09.834260'
+    - '2015-06-02 16:40:09.834260'
+    - 12
+    - false
+    - false
+    - false
+    - false
+    - false
+  - - 202
+    - Other Location
+    - other
+    - '2015-06-02 16:40:09.962775'
+    - '2015-06-02 16:40:09.962775'
+    - 13
+    - false
+    - false
+    - false
+    - true
+    - false
+  - - 203
+    - Harold P. Furth Plasma Physics Library
+    - ppl
+    - '2015-06-02 16:40:10.118498'
+    - '2015-06-02 16:40:10.118498'
+    - 14
+    - false
+    - false
+    - false
+    - true
+    - false
+  - - 204
+    - 'Harold P. Furth Plasma Physics Library: Indexes'
+    - pplia
+    - '2015-06-02 16:40:10.249747'
+    - '2015-06-02 16:40:10.249747'
+    - 14
+    - false
+    - false
+    - false
+    - false
+    - false
+  - - 205
+    - 'Harold P. Furth Plasma Physics Library: Seminar Room'
+    - pplla
+    - '2015-06-02 16:40:10.399852'
+    - '2015-06-02 16:40:10.399852'
+    - 14
+    - false
+    - false
+    - false
+    - false
+    - false
+  - - 206
+    - 'Harold P. Furth Plasma Physics Library: Office'
+    - pplli
+    - '2015-06-02 16:40:10.549454'
+    - '2015-06-02 16:40:10.549454'
+    - 14
+    - false
+    - false
+    - false
+    - false
+    - false
+  - - 207
+    - 'Harold P. Furth Plasma Physics Library: Periodicals'
+    - pplps
+    - '2015-06-02 16:40:10.683979'
+    - '2015-06-02 16:40:10.683979'
+    - 14
+    - false
+    - false
+    - false
+    - false
+    - false
+  - - 208
+    - 'Harold P. Furth Plasma Physics Library: Reserve'
+    - pplr
+    - '2015-06-02 16:40:10.836490'
+    - '2015-06-02 16:40:10.836490'
+    - 14
+    - false
+    - false
+    - false
+    - false
+    - false
+  - - 209
+    - 'Harold P. Furth Plasma Physics Library: Technical Reports'
+    - pplrdr
+    - '2015-06-02 16:40:11.004462'
+    - '2015-06-02 16:40:11.004462'
+    - 14
+    - false
+    - false
+    - false
+    - false
+    - false
+  - - 210
+    - 'Harold P. Furth Plasma Physics Library: Reference'
+    - pplrf
+    - '2015-06-02 16:40:11.165523'
+    - '2015-06-02 16:40:11.165523'
+    - 14
+    - false
+    - false
+    - false
+    - false
+    - false
+  - - 211
+    - 'Harold P. Furth Plasma Physics Library: Ready Reference'
+    - pplrr
+    - '2015-06-02 16:40:11.303387'
+    - '2015-06-02 16:40:11.303387'
+    - 14
+    - false
+    - false
+    - false
+    - false
+    - false
+  - - 212
+    - 'Firestone Library: Travel Guides'
+    - trv
+    - '2015-06-02 16:40:11.450599'
+    - '2015-06-02 16:40:11.450599'
+    - 6
+    - false
+    - false
+    - true
+    - false
+    - false
+  - - 213
+    - 'Harold P. Furth Plasma Physics Library: Theses'
+    - pplt
+    - '2015-06-02 16:40:11.594512'
+    - '2015-06-02 16:40:11.594512'
+    - 14
+    - false
+    - false
+    - false
+    - true
+    - false
+  - - 214
+    - 'Rare Books and Special Collections: Sylvia Beach Collection'
+    - beac
+    - '2015-06-02 16:40:11.735730'
+    - '2015-06-02 16:40:11.735730'
+    - 15
+    - true
+    - false
+    - false
+    - false
+    - true
+  - - 215
+    - 'Rare Books and Special Collections: Eugene B. Cook Chess Collection'
+    - cook
+    - '2015-06-02 16:40:11.875603'
+    - '2015-06-02 16:40:11.875603'
+    - 15
+    - true
+    - false
+    - false
+    - false
+    - true
+  - - 216
+    - 'Rare Books and Special Collections: Cotsen Children''s Library'
+    - ctsn
+    - '2015-06-02 16:40:12.034737'
+    - '2015-06-02 16:40:12.034737'
+    - 15
+    - true
+    - false
+    - false
+    - false
+    - true
+  - - 217
+    - 'Rare Books and Special Collections: Cotsen Children''s Library: Reference'
+    - ctsnrf
+    - '2015-06-02 16:40:12.171454'
+    - '2015-06-02 16:40:12.171454'
+    - 15
+    - true
+    - false
+    - false
+    - false
+    - true
+  - - 218
+    - 'Rare Books and Special Collections: Edwards Collection '
+    - ed
+    - '2015-06-02 16:40:12.314463'
+    - '2015-06-02 16:40:12.314463'
+    - 15
+    - true
+    - false
+    - false
+    - false
+    - true
+  - - 219
+    - Rare Books and Special Collections
+    - ex
+    - '2015-06-02 16:40:12.474853'
+    - '2015-06-02 16:40:12.474853'
+    - 15
+    - true
+    - false
+    - false
+    - false
+    - true
+  - - 220
+    - 'Rare Books and Special Collections: Reference Collection in Dulles Reading
+      Room'
+    - exb
+    - '2015-06-02 16:40:12.630826'
+    - '2015-06-02 16:40:12.630826'
+    - 15
+    - true
+    - false
+    - false
+    - false
+    - true
+  - - 221
+    - 'Rare Books and Special Collections: J. Harlin O''Connell Collection'
+    - exc
+    - '2015-06-02 16:40:12.772237'
+    - '2015-06-02 16:40:12.772237'
+    - 15
+    - true
+    - false
+    - false
+    - false
+    - true
+  - - 222
+    - 'Rare Books and Special Collections: Laurance Roberts Carton Hunting Collection'
+    - exca
+    - '2015-06-02 16:40:12.919249'
+    - '2015-06-02 16:40:12.919249'
+    - 15
+    - true
+    - false
+    - false
+    - false
+    - true
+  - - 223
+    - 'Rare Books and Special Collections: Kenneth McKenzie Fable Collection'
+    - exf
+    - '2015-06-02 16:40:13.079716'
+    - '2015-06-02 16:40:13.079716'
+    - 15
+    - true
+    - false
+    - false
+    - false
+    - true
+  - - 224
+    - 'Rare Books and Special Collections: Miriam Y. Holden Collection'
+    - exho
+    - '2015-06-02 16:40:13.236750'
+    - '2015-06-02 16:40:13.236750'
+    - 15
+    - true
+    - false
+    - false
+    - false
+    - true
+  - - 225
+    - 'Rare Books and Special Collections: Incunabula Collection'
+    - exi
+    - '2015-06-02 16:40:13.429413'
+    - '2015-06-02 16:40:13.429413'
+    - 15
+    - true
+    - false
+    - false
+    - false
+    - true
+  - - 226
+    - 'Rare Books and Special Collections: Kane Collection '
+    - exka
+    - '2015-06-02 16:40:13.608924'
+    - '2015-06-02 16:40:13.608924'
+    - 15
+    - true
+    - false
+    - false
+    - false
+    - true
+  - - 227
+    - 'Rare Books and Special Collections: Otto von Kienbusch Angling Collection'
+    - exki
+    - '2015-06-02 16:40:13.771868'
+    - '2015-06-02 16:40:13.771868'
+    - 15
+    - true
+    - false
+    - false
+    - false
+    - true
+  - - 228
+    - 'Rare Books and Special Collections: Charles Scribner Collection of Charles
+      Lamb'
+    - exl
+    - '2015-06-02 16:40:13.914060'
+    - '2015-06-02 16:40:13.914060'
+    - 15
+    - true
+    - false
+    - false
+    - false
+    - true
+  - - 229
+    - 'Rare Books and Special Collections: Robert Metzdorf Collection'
+    - exme
+    - '2015-06-02 16:40:14.070787'
+    - '2015-06-02 16:40:14.070787'
+    - 15
+    - true
+    - false
+    - false
+    - false
+    - true
+  - - 230
+    - 'Rare Books and Special Collections: Oversize '
+    - exov
+    - '2015-06-02 16:40:14.207687'
+    - '2015-06-02 16:40:14.207687'
+    - 15
+    - true
+    - false
+    - false
+    - false
+    - true
+  - - 231
+    - 'Rare Books and Special Collections: Morris L. Parrish Collection'
+    - expa
+    - '2015-06-02 16:40:14.378623'
+    - '2015-06-02 16:40:14.378623'
+    - 15
+    - true
+    - false
+    - false
+    - false
+    - true
+  - - 232
+    - 'Rare Books and Special Collections: Kenneth H. Rockey Angling Collection '
+    - exrc
+    - '2015-06-02 16:40:14.524724'
+    - '2015-06-02 16:40:14.524724'
+    - 15
+    - true
+    - false
+    - false
+    - false
+    - true
+  - - 233
+    - 'Rare Books and Special Collections: Leonard Milberg Coll. of American Poetry'
+    - exrl
+    - '2015-06-02 16:40:14.676584'
+    - '2015-06-02 16:40:14.676584'
+    - 15
+    - true
+    - false
+    - false
+    - false
+    - true
+  - - 234
+    - 'Rare Books and Special Collections: Rare Books'
+    - extr
+    - '2015-06-02 16:40:14.797823'
+    - '2015-06-02 16:40:14.797823'
+    - 15
+    - true
+    - false
+    - false
+    - false
+    - true
+  - - 235
+    - 'Rare Books and Special Collections: Technical Services Reference'
+    - extsf
+    - '2015-06-02 16:40:14.943262'
+    - '2015-06-02 16:40:14.943262'
+    - 15
+    - true
+    - false
+    - false
+    - false
+    - true
+  - - 236
+    - 'Rare Books and Special Collections: Harry B. Vandeventer Poetry Collection '
+    - exv
+    - '2015-06-02 16:40:15.090023'
+    - '2015-06-02 16:40:15.090023'
+    - 15
+    - true
+    - false
+    - false
+    - false
+    - true
+  - - 237
+    - 'Rare Books and Special Collections: Orlando F. Weber Coll. of Economic History'
+    - exw
+    - '2015-06-02 16:40:15.236905'
+    - '2015-06-02 16:40:15.236905'
+    - 15
+    - true
+    - false
+    - false
+    - false
+    - true
+  - - 238
+    - 'Rare Books and Special Collections: Graphic Arts Collection'
+    - ga
+    - '2015-06-02 16:40:15.405018'
+    - '2015-06-02 16:40:15.405018'
+    - 15
+    - true
+    - false
+    - false
+    - false
+    - true
+  - - 239
+    - 'Rare Books and Special Collections: Graphic Arts: Reference Collection'
+    - garf
+    - '2015-06-02 16:40:15.555245'
+    - '2015-06-02 16:40:15.555245'
+    - 15
+    - true
+    - false
+    - false
+    - false
+    - true
+  - - 240
+    - 'Rare Books and Special Collections: Graphic Arts Collection '
+    - gax
+    - '2015-06-02 16:40:15.717399'
+    - '2015-06-02 16:40:15.717399'
+    - 15
+    - true
+    - false
+    - false
+    - false
+    - true
+  - - 241
+    - 'Rare Books and Special Collections: South East (CTSN)'
+    - hsvc
+    - '2015-06-02 16:40:15.869128'
+    - '2015-06-02 16:40:15.869128'
+    - 15
+    - true
+    - false
+    - false
+    - true
+    - true
+  - - 242
+    - 'Rare Books and Special Collections: South East (East Asian)'
+    - hsve
+    - '2015-06-02 16:40:16.020349'
+    - '2015-06-02 16:40:16.020349'
+    - 15
+    - true
+    - false
+    - false
+    - true
+    - true
+  - - 243
+    - 'Rare Books and Special Collections: South East (GA)'
+    - hsvg
+    - '2015-06-02 16:40:16.211778'
+    - '2015-06-02 16:40:16.211778'
+    - 15
+    - true
+    - false
+    - false
+    - true
+    - true
+  - - 244
+    - 'Rare Books and Special Collections: South East (MSS)'
+    - hsvm
+    - '2015-06-02 16:40:16.363539'
+    - '2015-06-02 16:40:16.363539'
+    - 15
+    - true
+    - false
+    - false
+    - true
+    - true
+  - - 245
+    - 'Rare Books and Special Collections: South East (Num)'
+    - hsvn
+    - '2015-06-02 16:40:16.506287'
+    - '2015-06-02 16:40:16.506287'
+    - 15
+    - true
+    - false
+    - false
+    - true
+    - true
+  - - 246
+    - 'Rare Books and Special Collections: South East (HM)'
+    - hsvp
+    - '2015-06-02 16:40:16.672915'
+    - '2015-06-02 16:40:16.672915'
+    - 15
+    - true
+    - false
+    - false
+    - true
+    - true
+  - - 247
+    - 'Rare Books and Special Collections: South East (RB)'
+    - hsvr
+    - '2015-06-02 16:40:16.801556'
+    - '2015-06-02 16:40:16.801556'
+    - 15
+    - true
+    - false
+    - false
+    - true
+    - true
+  - - 248
+    - 'Rare Books and Special Collections: Laurence Hutton Collection'
+    - htn
+    - '2015-06-02 16:40:16.959602'
+    - '2015-06-02 16:40:16.959602'
+    - 15
+    - true
+    - false
+    - false
+    - false
+    - true
+  - - 249
+    - 'Rare Books and Special Collections: Historic Maps Collection'
+    - map
+    - '2015-06-02 16:40:17.115413'
+    - '2015-06-02 16:40:17.115413'
+    - 15
+    - true
+    - false
+    - false
+    - false
+    - true
+  - - 250
+    - 'Rare Books and Special Collections: Manuscripts Collection'
+    - mss
+    - '2015-06-02 16:40:17.280881'
+    - '2015-06-02 16:40:17.280881'
+    - 15
+    - true
+    - false
+    - false
+    - false
+    - true
+  - - 251
+    - 'Rare Books and Special Collections: Special Collections'
+    - njpg
+    - '2015-06-02 16:40:17.414678'
+    - '2015-06-02 16:40:17.414678'
+    - 15
+    - true
+    - false
+    - false
+    - false
+    - true
+  - - 252
+    - 'Rare Books and Special Collections: Numismatics Collection '
+    - num
+    - '2015-06-02 16:40:17.586233'
+    - '2015-06-02 16:40:17.586233'
+    - 15
+    - true
+    - false
+    - false
+    - false
+    - true
+  - - 253
+    - 'Rare Books and Special Collections: Numismatics Collection: Reference'
+    - numrf
+    - '2015-06-02 16:40:17.742946'
+    - '2015-06-02 16:40:17.742946'
+    - 15
+    - true
+    - false
+    - false
+    - false
+    - true
+  - - 254
+    - 'Rare Books and Special Collections: Princeton Borough Collection'
+    - pb
+    - '2015-06-02 16:40:17.867204'
+    - '2015-06-02 16:40:17.867204'
+    - 15
+    - true
+    - false
+    - false
+    - false
+    - true
+  - - 255
+    - 'Rare Books and Special Collections: Preservation Office'
+    - pres
+    - '2015-06-02 16:40:18.031115'
+    - '2015-06-02 16:40:18.031115'
+    - 15
+    - false
+    - false
+    - false
+    - false
+    - false
+  - - 256
+    - 'Rare Books and Special Collections: Robert Patterson Collection'
+    - ptt
+    - '2015-06-02 16:40:18.179857'
+    - '2015-06-02 16:40:18.179857'
+    - 15
+    - true
+    - false
+    - false
+    - false
+    - true
+  - - 257
+    - 'Rare Books and Special Collections: Robert H. Taylor Collection'
+    - rht
+    - '2015-06-02 16:40:18.338662'
+    - '2015-06-02 16:40:18.338662'
+    - 15
+    - true
+    - false
+    - false
+    - false
+    - true
+  - - 258
+    - 'Rare Books and Special Collections: Theatre Collection'
+    - thx
+    - '2015-06-02 16:40:18.475195'
+    - '2015-06-02 16:40:18.475195'
+    - 15
+    - true
+    - false
+    - false
+    - false
+    - true
+  - - 259
+    - 'Rare Books and Special Collections: Theatre Collection: Reference'
+    - thxr
+    - '2015-06-02 16:40:18.630419'
+    - '2015-06-02 16:40:18.630419'
+    - 15
+    - true
+    - false
+    - false
+    - false
+    - true
+  - - 260
+    - 'Rare Books and Special Collections: Junius Morgan Collection'
+    - vrg
+    - '2015-06-02 16:40:18.794104'
+    - '2015-06-02 16:40:18.794104'
+    - 15
+    - true
+    - false
+    - false
+    - false
+    - true
+  - - 261
+    - 'Rare Books and Special Collections: John Shaw Pierson Civil War Collection'
+    - w
+    - '2015-06-02 16:40:18.961648'
+    - '2015-06-02 16:40:18.961648'
+    - 15
+    - true
+    - false
+    - false
+    - false
+    - true
+  - - 262
+    - 'Rare Books and Special Collections: Western Americana Collection'
+    - wa
+    - '2015-06-02 16:40:19.103705'
+    - '2015-06-02 16:40:19.103705'
+    - 15
+    - true
+    - false
+    - false
+    - false
+    - true
+  - - 263
+    - 'Rare Books and Special Collections: William H. Scheide Library'
+    - whs
+    - '2015-06-02 16:40:19.238616'
+    - '2015-06-02 16:40:19.238616'
+    - 15
+    - true
+    - false
+    - false
+    - false
+    - true
+  - - 264
+    - 'Rare Books and Special Collections: John Witherspoon Library'
+    - wit
+    - '2015-06-02 16:40:19.379883'
+    - '2015-06-02 16:40:19.379883'
+    - 15
+    - true
+    - false
+    - false
+    - false
+    - true
+  - - 265
+    - 'ReCAP: Gov Docs.'
+    - rcpgp
+    - '2015-06-02 16:40:19.534189'
+    - '2015-06-02 16:40:19.534189'
+    - 16
+    - false
+    - false
+    - false
+    - true
+    - false
+  - - 266
+    - 'ReCAP: JSTOR Restricted'
+    - rcpjq
+    - '2015-06-02 16:40:19.688668'
+    - '2015-06-02 16:40:19.688668'
+    - 16
+    - false
+    - false
+    - false
+    - true
+    - false
+  - - 267
+    - ReCAP
+    - rcppa
+    - '2015-06-02 16:40:19.844354'
+    - '2015-06-02 16:40:19.844354'
+    - 16
+    - false
+    - false
+    - false
+    - true
+    - false
+  - - 268
+    - 'ReCAP: Supervised use in Firestone '
+    - rcppb
+    - '2015-06-02 16:40:20.022089'
+    - '2015-06-02 16:40:20.022089'
+    - 16
+    - false
+    - false
+    - false
+    - true
+    - false
+  - - 269
+    - 'ReCAP: Restricted Backup Copies'
+    - rcppe
+    - '2015-06-02 16:40:20.178726'
+    - '2015-06-02 16:40:20.178726'
+    - 16
+    - false
+    - false
+    - false
+    - true
+    - false
+  - - 270
+    - 'ReCAP: Use in Firestone Microforms only. '
+    - rcppf
+    - '2015-06-02 16:40:20.352967'
+    - '2015-06-02 16:40:20.352967'
+    - 16
+    - false
+    - false
+    - false
+    - true
+    - false
+  - - 271
+    - 'ReCAP: RBSC Off-Site Storage'
+    - rcppg
+    - '2015-06-02 16:40:20.518217'
+    - '2015-06-02 16:40:20.518217'
+    - 16
+    - true
+    - false
+    - false
+    - true
+    - true
+  - - 272
+    - 'ReCAP: Mudd Off-Site Storage'
+    - rcpph
+    - '2015-06-02 16:40:20.703495'
+    - '2015-06-02 16:40:20.703495'
+    - 16
+    - true
+    - false
+    - false
+    - true
+    - true
+  - - 273
+    - 'ReCAP: Marquand Library use only'
+    - rcppj
+    - '2015-06-02 16:40:20.859450'
+    - '2015-06-02 16:40:20.859450'
+    - 16
+    - false
+    - false
+    - false
+    - true
+    - false
+  - - 274
+    - 'ReCAP: Mendel Music Library use only.'
+    - rcppk
+    - '2015-06-02 16:40:21.049311'
+    - '2015-06-02 16:40:21.049311'
+    - 16
+    - false
+    - false
+    - false
+    - true
+    - false
+  - - 275
+    - 'ReCAP: East Asian Library use only'
+    - rcppl
+    - '2015-06-02 16:40:21.211765'
+    - '2015-06-02 16:40:21.211765'
+    - 16
+    - false
+    - false
+    - false
+    - true
+    - false
+  - - 276
+    - 'ReCAP: Donald E. Stokes Library use only.'
+    - rcppm
+    - '2015-06-02 16:40:21.392280'
+    - '2015-06-02 16:40:21.392280'
+    - 16
+    - false
+    - false
+    - false
+    - true
+    - false
+  - - 277
+    - 'ReCAP: Lewis Library use only.'
+    - rcppn
+    - '2015-06-02 16:40:21.591468'
+    - '2015-06-02 16:40:21.591468'
+    - 16
+    - false
+    - false
+    - false
+    - true
+    - false
+  - - 278
+    - 'ReCAP: Plasma Physics use only.'
+    - rcppq
+    - '2015-06-02 16:40:21.747394'
+    - '2015-06-02 16:40:21.747394'
+    - 16
+    - false
+    - false
+    - false
+    - true
+    - false
+  - - 279
+    - 'ReCAP: Lewis Library (Rare) use only'
+    - rcpps
+    - '2015-06-02 16:40:21.952532'
+    - '2015-06-02 16:40:21.952532'
+    - 16
+    - false
+    - false
+    - false
+    - true
+    - false
+  - - 280
+    - 'ReCAP: Technical Reports Offsite. Contact techrpts@princeton.edu'
+    - rcppt
+    - '2015-06-02 16:40:22.146372'
+    - '2015-06-02 16:40:22.146372'
+    - 16
+    - false
+    - false
+    - false
+    - true
+    - false
+  - - 281
+    - 'ReCAP: Architecture Library use only '
+    - rcppw
+    - '2015-06-02 16:40:22.355471'
+    - '2015-06-02 16:40:22.355471'
+    - 16
+    - false
+    - false
+    - false
+    - true
+    - false
+  - - 282
+    - 'ReCAP: Marquand Library (Rare) use only.'
+    - rcppz
+    - '2015-06-02 16:40:22.515248'
+    - '2015-06-02 16:40:22.515248'
+    - 16
+    - true
+    - false
+    - false
+    - true
+    - true
+  - - 283
+    - 'ReCAP: Reading Room use only.'
+    - rcpqb
+    - '2015-06-02 16:40:22.695910'
+    - '2015-06-02 16:40:22.695910'
+    - 16
+    - false
+    - false
+    - false
+    - true
+    - false
+  - - 284
+    - 'ReCAP: Mendel Music Library use only. '
+    - rcpqk
+    - '2015-06-02 16:40:22.891381'
+    - '2015-06-02 16:40:22.891381'
+    - 16
+    - false
+    - false
+    - false
+    - true
+    - false
+  - - 285
+    - 'ReCAP: Firestone Microforms or East Asian Library use only'
+    - rcpql
+    - '2015-06-02 16:40:23.059181'
+    - '2015-06-02 16:40:23.059181'
+    - 16
+    - false
+    - false
+    - false
+    - true
+    - false
+  - - 286
+    - 'ReCAP: Humanities Resource Center use only'
+    - rcpqv
+    - '2015-06-02 16:40:23.257217'
+    - '2015-06-02 16:40:23.257217'
+    - 16
+    - false
+    - false
+    - false
+    - true
+    - false
+  - - 287
+    - 'ReCAP: Broadcast Center use only'
+    - rcpqx
+    - '2015-06-02 16:40:23.480483'
+    - '2015-06-02 16:40:23.480483'
+    - 16
+    - false
+    - false
+    - false
+    - true
+    - false
+  - - 288
+    - 'ReCAP: Cotsen Library Off-Site Storage'
+    - rcpxc
+    - '2015-06-02 16:40:23.616226'
+    - '2015-06-02 16:40:23.616226'
+    - 16
+    - true
+    - false
+    - false
+    - true
+    - true
+  - - 289
+    - 'ReCAP: Graphic Arts Off-Site Storage'
+    - rcpxg
+    - '2015-06-02 16:40:23.752396'
+    - '2015-06-02 16:40:23.752396'
+    - 16
+    - true
+    - false
+    - false
+    - true
+    - true
+  - - 290
+    - 'ReCAP: Manuscripts Off-Site Storage'
+    - rcpxm
+    - '2015-06-02 16:40:23.947782'
+    - '2015-06-02 16:40:23.947782'
+    - 16
+    - true
+    - false
+    - false
+    - true
+    - true
+  - - 291
+    - 'ReCAP: Numismatics Off-Site Storage'
+    - rcpxn
+    - '2015-06-02 16:40:24.088510'
+    - '2015-06-02 16:40:24.088510'
+    - 16
+    - true
+    - false
+    - false
+    - true
+    - true
+  - - 292
+    - 'ReCAP: Historic Maps Off-Site Storage'
+    - rcpxp
+    - '2015-06-02 16:40:24.228821'
+    - '2015-06-02 16:40:24.228821'
+    - 16
+    - true
+    - false
+    - false
+    - true
+    - true
+  - - 293
+    - 'ReCAP: Rare Books Off-Site Storage'
+    - rcpxr
+    - '2015-06-02 16:40:24.385005'
+    - '2015-06-02 16:40:24.385005'
+    - 16
+    - true
+    - false
+    - false
+    - true
+    - true
+  - - 294
+    - 'ReCAP: Special Items Off-Site Storage'
+    - rcpxx
+    - '2015-06-02 16:40:24.549220'
+    - '2015-06-02 16:40:24.549220'
+    - 16
+    - true
+    - false
+    - false
+    - true
+    - true
+  - - 295
+    - 'Stokes Library: Computer Media'
+    - ltoppiapr
+    - '2015-06-02 16:40:24.698536'
+    - '2015-06-02 16:40:24.698536'
+    - 17
+    - false
+    - false
+    - false
+    - false
+    - false
+  - - 296
+    - Stokes Library
+    - piapr
+    - '2015-06-02 16:40:24.838655'
+    - '2015-06-02 16:40:24.838655'
+    - 17
+    - false
+    - false
+    - true
+    - false
+    - false
+  - - 297
+    - 'Stokes Library: Reserve'
+    - piaprr
+    - '2015-06-02 16:40:24.997249'
+    - '2015-06-02 16:40:24.997249'
+    - 17
+    - false
+    - false
+    - false
+    - false
+    - false
+  - - 298
+    - Stokes Library
+    - spia
+    - '2015-06-02 16:40:25.151565'
+    - '2015-06-02 16:40:25.151565'
+    - 17
+    - false
+    - false
+    - true
+    - false
+    - false
+  - - 299
+    - 'Stokes Library: Atlases'
+    - spiaa
+    - '2015-06-02 16:40:25.275042'
+    - '2015-06-02 16:40:25.275042'
+    - 17
+    - false
+    - false
+    - true
+    - false
+    - false
+  - - 300
+    - 'Stokes Library: Indexes'
+    - spiai
+    - '2015-06-02 16:40:25.421182'
+    - '2015-06-02 16:40:25.421182'
+    - 17
+    - false
+    - false
+    - false
+    - false
+    - false
+  - - 301
+    - 'Stokes Library: Periodicals'
+    - spiaps
+    - '2015-06-02 16:40:25.570906'
+    - '2015-06-02 16:40:25.570906'
+    - 17
+    - false
+    - false
+    - true
+    - false
+    - false
+  - - 302
+    - 'Stokes Library: Reference'
+    - spiarf
+    - '2015-06-02 16:40:25.709292'
+    - '2015-06-02 16:40:25.709292'
+    - 17
+    - false
+    - false
+    - false
+    - false
+    - false
+  - - 303
+    - 'Stokes Library: Writing Shelf'
+    - spiaws
+    - '2015-06-02 16:40:25.855625'
+    - '2015-06-02 16:40:25.855625'
+    - 17
+    - false
+    - false
+    - false
+    - false
+    - false
+  - - 304
+    - 'Stokes Library: Reserve'
+    - spir
+    - '2015-06-02 16:40:26.005171'
+    - '2015-06-02 16:40:26.005171'
+    - 17
+    - false
+    - false
+    - false
+    - false
+    - false
+  - - 305
+    - Stokes Library
+    - spr
+    - '2015-06-02 16:40:26.162658'
+    - '2015-06-02 16:40:26.162658'
+    - 17
+    - false
+    - false
+    - true
+    - false
+    - false
+  - - 306
+    - 'Stokes Library: Microforms'
+    - sprf
+    - '2015-06-02 16:40:26.326648'
+    - '2015-06-02 16:40:26.326648'
+    - 17
+    - false
+    - false
+    - false
+    - true
+    - false
+
+---
+locations_holdings_delivery:
+  columns:
+  - locations_delivery_location_id
+  - locations_holding_location_id
+  records: 
+  - - 2
+    - 15
+  - - 18
+    - 5
+  - - 21
+    - 3
+  - - 22
+    - 3
+  - - 23
+    - 3
+  - - 26
+    - 4
+  - - 27
+    - 4
+  - - 31
+    - 4
+  - - 32
+    - 4
+  - - 33
+    - 4
+  - - 48
+    - 4
+  - - 49
+    - 4
+  - - 51
+    - 4
+  - - 52
+    - 4
+  - - 55
+    - 5
+  - - 57
+    - 5
+  - - 87
+    - 6
+  - - 87
+    - 24
+  - - 152
+    - 14
+  - - 185
+    - 8
+  - - 186
+    - 8
+  - - 187
+    - 8
+  - - 188
+    - 8
+  - - 193
+    - 8
+  - - 196
+    - 8
+  - - 265
+    - 1
+  - - 265
+    - 3
+  - - 265
+    - 4
+  - - 265
+    - 5
+  - - 265
+    - 6
+  - - 265
+    - 7
+  - - 265
+    - 8
+  - - 265
+    - 9
+  - - 265
+    - 10
+  - - 265
+    - 13
+  - - 265
+    - 14
+  - - 265
+    - 15
+  - - 265
+    - 17
+  - - 265
+    - 12
+  - - 265
+    - 2
+  - - 265
+    - 29
+  - - 265
+    - 23
+  - - 266
+    - 29
+  - - 266
+    - 23
+  - - 266
+    - 2
+  - - 267
+    - 1
+  - - 267
+    - 3
+  - - 267
+    - 4
+  - - 267
+    - 5
+  - - 267
+    - 6
+  - - 267
+    - 7
+  - - 267
+    - 8
+  - - 267
+    - 9
+  - - 267
+    - 10
+  - - 267
+    - 13
+  - - 267
+    - 14
+  - - 267
+    - 15
+  - - 267
+    - 17
+  - - 267
+    - 12
+  - - 267
+    - 2
+  - - 267
+    - 29
+  - - 267
+    - 23
+  - - 268
+    - 28
+  - - 268
+    - 2
+  - - 268
+    - 23
+  - - 268
+    - 29
+  - - 269
+    - 2
+  - - 269
+    - 23
+  - - 269
+    - 29
+  - - 270
+    - 6
+  - - 270
+    - 15
+  - - 270
+    - 12
+  - - 270
+    - 2
+  - - 270
+    - 29
+  - - 270
+    - 23
+  - - 271
+    - 13
+  - - 272
+    - 9
+  - - 273
+    - 7
+  - - 273
+    - 23
+  - - 273
+    - 2
+  - - 273
+    - 29
+  - - 274
+    - 8
+  - - 274
+    - 29
+  - - 274
+    - 23
+  - - 274
+    - 2
+  - - 275
+    - 4
+  - - 275
+    - 29
+  - - 275
+    - 23
+  - - 275
+    - 2
+  - - 276
+    - 10
+  - - 276
+    - 29
+  - - 276
+    - 23
+  - - 276
+    - 2
+  - - 277
+    - 14
+  - - 277
+    - 23
+  - - 277
+    - 29
+  - - 277
+    - 2
+  - - 278
+    - 1
+  - - 278
+    - 14
+  - - 278
+    - 23
+  - - 278
+    - 2
+  - - 278
+    - 29
+  - - 279
+    - 14
+  - - 279
+    - 2
+  - - 279
+    - 23
+  - - 279
+    - 29
+  - - 280
+    - 5
+  - - 280
+    - 29
+  - - 280
+    - 23
+  - - 280
+    - 2
+  - - 281
+    - 3
+  - - 281
+    - 2
+  - - 281
+    - 23
+  - - 281
+    - 29
+  - - 282
+    - 7
+  - - 283
+    - 16
+  - - 283
+    - 2
+  - - 283
+    - 29
+  - - 283
+    - 23
+  - - 284
+    - 8
+  - - 284
+    - 29
+  - - 284
+    - 23
+  - - 284
+    - 2
+  - - 284
+    - 12
+  - - 285
+    - 4
+  - - 285
+    - 6
+  - - 285
+    - 29
+  - - 285
+    - 23
+  - - 285
+    - 2
+  - - 286
+    - 17
+  - - 286
+    - 2
+  - - 286
+    - 23
+  - - 286
+    - 29
+  - - 288
+    - 19
+  - - 289
+    - 20
+  - - 290
+    - 9
+  - - 291
+    - 21
+  - - 292
+    - 22
+  - - 293
+    - 13
+  - - 294
+    - 13

--- a/locations.gemspec
+++ b/locations.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'rails', '~> 4.2.1'
   s.add_dependency 'bootstrap-sass', '~> 3.3.4'
   s.add_dependency 'friendly_id', '~> 5.1.0'
+  s.add_dependency 'yaml_db', '~> 0.3.0'
 
   s.add_development_dependency 'sqlite3'
   s.add_development_dependency 'rspec-rails', '~> 3.1'

--- a/spec/features/locations/delete_library_spec.rb
+++ b/spec/features/locations/delete_library_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-feature 'Javascript delete location confirmation dialog', type: :feature, js: true do
+feature 'Javascript delete library confirmation dialog', type: :feature, js: true do
   before :all do
     FactoryGirl.create(:library)
   end

--- a/spec/features/locations/holding_delivery_association_spec.rb
+++ b/spec/features/locations/holding_delivery_association_spec.rb
@@ -2,6 +2,7 @@ require 'spec_helper'
 
 feature 'Holding Location Delivery Location Multiselect', type: :feature do
 
+  let(:delivery_location) { FactoryGirl.create(:delivery_location, staff_only: false) }
   let(:holding_location) { FactoryGirl.create(:holding_location) }
   before { 5.times { FactoryGirl.create(:delivery_location) } }
 
@@ -22,4 +23,11 @@ feature 'Holding Location Delivery Location Multiselect', type: :feature do
     end
 
   end
+
+  scenario 'Links to delivery locations from holding location' do
+    delivery_location
+    visit holding_location_path(holding_location)
+    click_link delivery_location.label
+  end
+
 end

--- a/spec/features/locations/location_views_associated_links_spec.rb
+++ b/spec/features/locations/location_views_associated_links_spec.rb
@@ -1,0 +1,43 @@
+require 'spec_helper'
+
+feature 'Holding Location views link to other associated locations', type: :feature do
+
+  let(:library) { FactoryGirl.create(:library) }
+  let(:delivery_location) { FactoryGirl.create(:delivery_location) }
+  let(:holding_location) { FactoryGirl.create(:holding_location) }
+
+  scenario 'Link to library from library label rather than extra show link' do
+    library
+    visit libraries_path
+    click_link library.label
+  end
+
+  scenario 'Link to holding location from holding location label rather than extra show link' do
+    holding_location
+    visit holding_locations_path
+    click_link holding_location.label
+  end
+
+  scenario 'Link to delivery location from delivery location label rather than extra show link' do
+    delivery_location
+    visit delivery_locations_path
+    click_link delivery_location.label
+  end
+
+  scenario 'User can link to library associated with holding location from show view' do
+    visit holding_locations_path(holding_location)
+    click_link holding_location.library.code
+  end  
+
+  scenario 'User can link to library associated with delivery location from index view' do
+    delivery_location
+    visit delivery_locations_path
+    click_link delivery_location.library.code
+  end
+
+  scenario 'User can link to library associated with delivery location from show view' do
+    visit delivery_locations_path(delivery_location)
+    click_link delivery_location.library.code
+  end  
+
+end

--- a/spec/models/locations/library_spec.rb
+++ b/spec/models/locations/library_spec.rb
@@ -45,6 +45,26 @@ module Locations
             FactoryGirl.create(:library, code: 'mycode42')
           }.to_not raise_error
         end
+        it 'new is a valid code for friendly_id' do
+          expect {
+            FactoryGirl.create(:library, code: 'new')
+          }.to_not raise_error
+        end
+        it 'code can be 1 character' do
+          expect {
+            FactoryGirl.create(:library, code: 'f')
+          }.to_not raise_error
+        end
+        it 'code can be 12 characters' do
+          expect {
+            FactoryGirl.create(:library, code: 'architecture')
+          }.to_not raise_error
+        end
+        it 'may not be create' do
+          expect {
+            FactoryGirl.create(:library, code: 'create')
+          }.to raise_error ActiveRecord::RecordInvalid
+        end
       end
 
     end

--- a/spec/requests/locations/holding_locations_json_view_spec.rb
+++ b/spec/requests/locations/holding_locations_json_view_spec.rb
@@ -81,5 +81,69 @@ module Locations
       end
 
     end
+
+
+  end
+
+  describe 'HoldingLocation html view', type: :request do
+
+    it 'Renders the html template by default' do
+      get holding_locations_path
+      expect(response).to render_template(:index)
+      expect(response.content_type).to eq 'text/html'
+    end
+
+    describe 'the response body' do
+
+      it "/holding_locations contains expected fields" do
+        2.times { FactoryGirl.create(:holding_location) }
+        expected = []
+        HoldingLocation.all.each do |holding_location|
+          attrs = [
+            CGI::escapeHTML(holding_location.label),
+            holding_location.code,
+            holding_location.aeon_location,
+            holding_location.recap_electronic_delivery_location,
+            holding_location.open,
+            holding_location.requestable,
+            holding_location.always_requestable,
+            holding_location.library.code
+          ]
+          expected << attrs
+        end
+        expected << ['Aeon Location', 'ReCAP Electronic Delivery Location',
+         'Open', 'Requestable', 'Always Requestable']
+        get holding_locations_path
+        expected.flatten.uniq.each {|e| expect(response.body).to include(e.to_s)}
+
+      end
+
+      it "/holding_locations/{code} contains expected fields" do
+        FactoryGirl.create(:library)
+        FactoryGirl.create(:delivery_location)
+        holding_location = FactoryGirl.create(:holding_location)
+        2.times do
+          dl = FactoryGirl.create(:delivery_location)
+          holding_location.delivery_locations << dl
+        end
+        holding_location.reload
+        expected = [
+          CGI::escapeHTML(holding_location.label),
+          holding_location.code,
+          holding_location.aeon_location,
+          holding_location.recap_electronic_delivery_location,
+          holding_location.open,
+          holding_location.requestable,
+          holding_location.always_requestable,
+          holding_location.library.code
+        ]
+        holding_location.delivery_locations.each {
+          |dl| expected << CGI::escapeHTML(dl.label) }
+        get holding_location_path(holding_location)
+        expected.each {|e| expect(response.body).to include(e.to_s)}
+      end
+
+    end
+
   end
 end

--- a/spec/requests/locations/libraries_json_view_spec.rb
+++ b/spec/requests/locations/libraries_json_view_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 module Locations
-  describe 'Librarie json view', type: :request do
+  describe 'Library json view', type: :request do
 
     it 'Renders the json template' do
       get libraries_path, format: :json

--- a/spec/routing/locations/delivery_locations_routing_spec.rb
+++ b/spec/routing/locations/delivery_locations_routing_spec.rb
@@ -10,8 +10,8 @@ describe Locations::DeliveryLocationsController, type: :routing do
       expect(get: '/delivery_locations').to route_to('locations/delivery_locations#index')
     end
 
-    it 'routes to #new' do
-      expect(get: '/delivery_locations/new').to route_to('locations/delivery_locations#new')
+    it 'routes to #create' do
+      expect(get: '/delivery_locations/create').to route_to('locations/delivery_locations#new')
     end
 
     it 'routes to #show' do

--- a/spec/routing/locations/holding_locations_routing_spec.rb
+++ b/spec/routing/locations/holding_locations_routing_spec.rb
@@ -9,8 +9,8 @@ describe Locations::HoldingLocationsController, type: :routing do
       expect(get: '/holding_locations').to route_to('locations/holding_locations#index')
     end
 
-    it 'routes to #new' do
-      expect(get: '/holding_locations/new').to route_to('locations/holding_locations#new')
+    it 'routes to #create' do
+      expect(get: '/holding_locations/create').to route_to('locations/holding_locations#new')
     end
 
     it 'routes to #show' do

--- a/spec/routing/locations/libraries_routing_spec.rb
+++ b/spec/routing/locations/libraries_routing_spec.rb
@@ -9,8 +9,8 @@ describe Locations::LibrariesController, type: :routing do
       expect(get: '/libraries').to route_to('locations/libraries#index')
     end
 
-    it 'routes to #new' do
-      expect(get: '/libraries/new').to route_to('locations/libraries#new')
+    it 'routes to #create' do
+      expect(get: '/libraries/create').to route_to('locations/libraries#new')
     end
 
     it 'routes to #show' do

--- a/spec/test_app_templates/lib/generators/test_app_generator.rb
+++ b/spec/test_app_templates/lib/generators/test_app_generator.rb
@@ -13,6 +13,7 @@ class TestAppGenerator < Rails::Generators::Base
 
   def add_gems
     gem 'bootstrap-sass', '~> 3.3.4'
+    gem 'yaml_db', '~> 0.3.0'
     gem 'factory_girl_rails', '~> 4.5.0', group: [:development, :test]
     gem 'faker', '~> 1.4.3', group: [:development, :test]
     Bundler.with_clean_env do
@@ -23,6 +24,7 @@ class TestAppGenerator < Rails::Generators::Base
   def friendly_id
     gem 'friendly_id', '~> 5.1.0'
     generate 'friendly_id'
+    gsub_file 'config/initializers/friendly_id.rb', 'new edit', 'create edit'
   end
 
   def inject_routes
@@ -36,4 +38,10 @@ class TestAppGenerator < Rails::Generators::Base
     rake "db:migrate"
     rake "db:migrate RAILS_ENV=test"
   end
+
+  def add_locations
+    copy_file "../../lib/locations/data.yml", "db/data.yml"
+    rake 'db:data:load'
+  end
+
 end


### PR DESCRIPTION
Database is stored in `lib/locatons/data.yml` which gets copied into the app which mounts this engine. Data gets loaded when running the generator using [yaml_db](https://github.com/yamldb/yaml_db) gem.

Codes are now 1-12 characters long to reflect current library data.

Since `new` is a holding location code, the routes have been changed to allow `new` to be a valid code url_slug. The route for creating any location is now `/locations/location_type/create` while still routing to the `location_type#new` action.

Closes #26, closes #27, closes #28.
