### PR TITLE
allow links to display in flash (no user input in messages)

### DIFF
--- a/app/views/shared/_error_flash_message.html.erb
+++ b/app/views/shared/_error_flash_message.html.erb
@@ -1,6 +1,6 @@
 <h2><%= pluralize(flash[:error].count, "error") %> prohibited this holding_location from being saved:</h2>
 <ul>
 	<% flash[:error].each do |message| %>
-		<li><%= message %></li>
+		<li><%= message.html_safe %></li>
 	<% end %>
 </ul>

--- a/app/views/shared/_flash_messages.html.erb
+++ b/app/views/shared/_flash_messages.html.erb
@@ -1,5 +1,5 @@
 <% flash.each do |type, message| %>
   <div class="alert <%= bootstrap_class_for(type) %> fade in">
-    <%= type == 'error' ? (render partial: "shared/error_flash_message") : message %>
+    <%= type == 'error' ? (render partial: "shared/error_flash_message") : message.html_safe %>
   </div>
 <% end %>


### PR DESCRIPTION
I included a flash message link to sign out from cas after signing out from bib data. I needed to make the flash messages html_safe in order for the link to render.