### PR TITLE
Library sort

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ script: bundle exec rake ci
 
 branches:
   only:
-    - development
+    - master
 notifications:
   email:
     recipients:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # PUL Locations
 
-[![Build Status](https://travis-ci.org/pulibrary/locations.png?branch=development)](https://travis-ci.org/pulibrary/locations)
-[![Coverage Status](https://coveralls.io/repos/pulibrary/locations/badge.svg?branch=development)](https://coveralls.io/r/pulibrary/locations?branch=development)
+[![Build Status](https://travis-ci.org/pulibrary/locations.png?branch=master)](https://travis-ci.org/pulibrary/locations)
+[![Coverage Status](https://coveralls.io/repos/pulibrary/locations/badge.svg?branch=master)](https://coveralls.io/r/pulibrary/locations?branch=master)
 
 A mountable Rails Engine for managing PUL Library, Holding, Hours, and Delivery location data, including forms for managing that data and JSON APIs for integration with other services.
 
@@ -21,7 +21,7 @@ Note: [phantomjs](http://phantomjs.org/download.html) must be installed and in y
 In your application gemfile add
 
 ```
-gem 'locations', git: 'git@github.com:pulibrary/locations.git', branch: 'development'
+gem 'locations', git: 'git@github.com:pulibrary/locations.git', branch: 'master'
 ```
 
 Then run

--- a/app/assets/javascripts/locations/application.js
+++ b/app/assets/javascripts/locations/application.js
@@ -2,5 +2,6 @@
 //= require jquery_ujs
 //= require bootstrap-sprockets
 //= require jquery-tablesorter
+//= require jquery-tablesorter/widgets/widget-editable
 //= require locations/tablesorter
 //= require locations/libraries

--- a/app/assets/javascripts/locations/libraries.js
+++ b/app/assets/javascripts/locations/libraries.js
@@ -9,4 +9,55 @@ $(document).ready(function(){
     console.log(this);
     $(this).siblings('.floor-form').toggle();
   });
+
+  // tablesorter editable position
+  $("table.reorder").tablesorter({
+    sortList: [[0,0]],
+    widthFixed: true,
+    widgets: ['stickyHeaders', 'filter', 'zebra', 'editable'],
+    widgetOptions: {
+      stickyHeaders_offset: 50,
+      editable_columns       : [0],       // or "0-2" (v2.14.2); point to the columns to make editable (zero-based index)
+      editable_enterToAccept : true,          // press enter to accept content, or click outside if false
+      editable_autoAccept    : true,          // accepts any changes made to the table cell automatically (v2.17.6)
+      editable_autoResort    : true,         // auto resort after the content has changed.
+      editable_validate      : function(text, original, columnIndex){
+        if(Math.floor(text) == text && $.isNumeric(text))
+          return text;
+        else
+          return original; },
+      editable_focused       : function(txt, columnIndex, $element) {
+        // $element is the div, not the td
+        // to get the td, use $element.closest('td')
+        $element.addClass('focused');
+      },
+      editable_blur          : function(txt, columnIndex, $element) {
+        // $element is the div, not the td
+        // to get the td, use $element.closest('td')
+        $element.removeClass('focused');
+      },
+      editable_selectAll     : function(txt, columnIndex, $element){
+        // note $element is the div inside of the table cell, so use $element.closest('td') to get the cell
+        // only select everthing within the element when the content starts with the letter "B"
+        return /^b/i.test(txt) && columnIndex === 0;
+      },
+      editable_wrapContent   : '<div>',       // wrap all editable cell content... makes this widget work in IE, and with autocomplete
+      editable_trimContent   : true,          // trim content ( removes outer tabs & carriage returns )
+      editable_noEdit        : 'no-edit',     // class name of cell that is not editable
+      editable_editComplete  : 'editComplete' // event fired after the table content has been edited
+    }
+  })
+  // config event variable new in v2.17.6
+  .children('tbody').on('editComplete', 'td', function(event, config){
+    var $this = $(this),
+      newContent = $this.text(),
+      cellIndex = this.cellIndex, // there shouldn't be any colspans in the tbody
+      rowIndex = $this.closest('tr').attr('id'); // data-row-index stored in row id
+    $.ajax({
+      method: "PATCH",
+      url: "libraries/" + rowIndex,
+      data: { order: newContent },
+      dataType: 'script'
+    });
+  });
 })

--- a/app/assets/javascripts/locations/tablesorter.js
+++ b/app/assets/javascripts/locations/tablesorter.js
@@ -1,10 +1,10 @@
 jQuery(function() {
-    // tablesorter
-    $("table").tablesorter({
-        widthFixed: true,
-        widgets: ['stickyHeaders', 'filter', 'zebra'],
-        widgetOptions: {
-          stickyHeaders_offset: 50,
-        }
-    });
+  // tablesorter
+  $("table.sortonly").tablesorter({
+      widthFixed: true,
+      widgets: ['stickyHeaders', 'filter', 'zebra'],
+      widgetOptions: {
+        stickyHeaders_offset: 50,
+      }
+  });
 });

--- a/app/assets/stylesheets/locations/application.scss
+++ b/app/assets/stylesheets/locations/application.scss
@@ -10,3 +10,12 @@ body {
 .form-text-box {
   padding-top: 1em;
 }
+
+.tablesorter tbody > tr > td[contenteditable=true]:focus {
+  outline: #08f 1px solid;
+  background: #eee;
+  resize: none;
+}
+td.no-edit, span.no-edit {
+  background-color: rgba(230,191,153,0.5);
+}

--- a/app/controllers/locations/libraries_controller.rb
+++ b/app/controllers/locations/libraries_controller.rb
@@ -6,7 +6,7 @@ module Locations
 
     # GET /libraries
     def index
-      @libraries = Library.all
+      @libraries = Library.all.order(:order, :label)
     end
 
     # GET /libraries/1
@@ -38,11 +38,18 @@ module Locations
 
     # PATCH/PUT /libraries/1
     def update
-      if @library.update(library_params)
-        redirect_to @library, notice: 'Library was successfully updated.'
-      else
-        flash.now[:error] = @library.errors.full_messages
-        render :edit
+      respond_to do |format|
+        format.html {
+          if @library.update(library_params)
+            redirect_to @library, notice: 'Library was successfully updated.'
+          else
+            flash.now[:error] = @library.errors.full_messages
+            render :edit
+          end
+        }
+        format.js {
+          @library.update(order: params[:order])
+        }
       end
     end
 
@@ -60,7 +67,7 @@ module Locations
 
       # Only allow a trusted parameter "white list" through.
       def library_params
-        params.require(:library).permit(:label, :code, locations_floor_ids: [], floors_attributes: [ :id, :label, :floor_plan_image, :_destroy])
+        params.require(:library).permit(:label, :code, :order, locations_floor_ids: [], floors_attributes: [ :id, :label, :floor_plan_image, :_destroy])
       end
   end
 end

--- a/app/uploaders/locations/floorplan_uploader.rb
+++ b/app/uploaders/locations/floorplan_uploader.rb
@@ -38,7 +38,7 @@ module Locations
 
     # Add a white list of extensions which are allowed to be uploaded.
     # For images you might use something like this:
-    def extension_white_list
+    def extension_whitelist
       %w(jpg jpeg gif png)
     end
 

--- a/app/views/locations/delivery_locations/index.html.erb
+++ b/app/views/locations/delivery_locations/index.html.erb
@@ -1,6 +1,6 @@
 <h1>Delivery Locations</h1>
 
-<table class="table tablesorter tablesorter-blue">
+<table class="table tablesorter tablesorter-blue sortonly">
   <thead>
     <tr>
       <th>Label</th>

--- a/app/views/locations/floors/index.html.erb
+++ b/app/views/locations/floors/index.html.erb
@@ -1,6 +1,6 @@
 <h1>Listing Floors</h1>
 
-<table class="tablesorter tablesorter-blue">
+<table class="tablesorter tablesorter-blue sortonly">
   <thead>
     <tr>
       <th>Label</th>

--- a/app/views/locations/holding_locations/index.html.erb
+++ b/app/views/locations/holding_locations/index.html.erb
@@ -1,6 +1,6 @@
 <h1>Holding Locations</h1>
 
-<table class="tablesorter tablesorter-blue">
+<table class="tablesorter tablesorter-blue sortonly">
   <thead>
     <tr>
       <th>Code</th>

--- a/app/views/locations/hours_locations/index.html.erb
+++ b/app/views/locations/hours_locations/index.html.erb
@@ -1,6 +1,6 @@
 <h1>Hours Locations</h1>
 
-<table class="table tablesorter tablesorter-blue">
+<table class="table tablesorter tablesorter-blue sortonly">
   <thead>
     <tr>
       <th>Label</th>

--- a/app/views/locations/libraries/_form.html.erb
+++ b/app/views/locations/libraries/_form.html.erb
@@ -8,6 +8,10 @@
     <%= f.label :code %><br>
     <%= f.text_field :code %>
   </div>
+  <div class="field">
+    <%= f.label :order %><br>
+    <%= f.text_field :order %>
+  </div>
 <% if params[:action] == 'edit' %>
   <div class="floors">
     <h2>Floors</h2>

--- a/app/views/locations/libraries/_show_single.json.jbuilder
+++ b/app/views/locations/libraries/_show_single.json.jbuilder
@@ -1,1 +1,1 @@
-json.extract! library, :label, :code
+json.extract! library, :label, :code, :order

--- a/app/views/locations/libraries/index.html.erb
+++ b/app/views/locations/libraries/index.html.erb
@@ -1,8 +1,9 @@
 <h1>Libraries</h1>
 
-<table class="table tablesorter tablesorter-blue">
+<table class="table tablesorter tablesorter-blue reorder">
   <thead>
     <tr>
+      <th>Order</th>
       <th>Label</th>
       <th>Code</th>
       <th colspan="1" class="sorter-false filter-false"></th>
@@ -12,7 +13,8 @@
 
   <tbody>
     <% @libraries.each do |library| %>
-      <tr>
+      <tr id="<%= library.id %>">
+        <td><%= library.order %></td>
         <td><%= link_to library.label, library %></td>
         <td><%= library.code %></td>
         <td><%= link_to 'Edit', edit_library_path(library) %></td>

--- a/app/views/locations/libraries/show.html.erb
+++ b/app/views/locations/libraries/show.html.erb
@@ -9,6 +9,11 @@
 </p>
 
 <p>
+  <strong>Order:</strong>
+  <%= @library.order %>
+</p>
+
+<p>
 	<dl>
 	  <dt><strong>Floors:</strong></dt>
 	  <dd>

--- a/db/migrate/20161228195737_add_order_to_locations_libraries.rb
+++ b/db/migrate/20161228195737_add_order_to_locations_libraries.rb
@@ -1,0 +1,5 @@
+class AddOrderToLocationsLibraries < ActiveRecord::Migration
+  def change
+    add_column :locations_libraries, :order, :integer, default: 0
+  end
+end

--- a/lib/locations/version.rb
+++ b/lib/locations/version.rb
@@ -1,3 +1,3 @@
 module Locations
-  VERSION = "0.3.0"
+  VERSION = "0.5.0"
 end

--- a/spec/controllers/locations/libraries_controller_spec.rb
+++ b/spec/controllers/locations/libraries_controller_spec.rb
@@ -95,7 +95,7 @@ module Locations
       end
     end
 
-    describe "PUT #update" do
+    describe "PUT/PATCH #update" do
       let(:library) { FactoryGirl.create(:library) }
       let(:updated_label) { 'Updated Label'}
       let(:new_attributes) {
@@ -124,6 +124,17 @@ module Locations
         it "redirects to the library" do
           put :update, valid_params, valid_session
           expect(response).to redirect_to(library)
+        end
+      end
+
+      context "using ajax" do
+        let(:updated_order) { 15 }
+        let(:ajax_params) { { order: updated_order, id: library.id, format: :js } }
+        it "updates the requested library's order" do
+          original_order = library[:order]
+          expect {
+              patch :update, ajax_params
+            }.to change { library.reload[:order] }.from(original_order).to(updated_order)
         end
       end
 

--- a/spec/factories/locations/library.rb
+++ b/spec/factories/locations/library.rb
@@ -5,6 +5,7 @@ FactoryGirl.define do
   factory :library, class: Locations::Library do
     label { Faker::Company.name + ' Library'}
     code
+    order { rand(0..10) }
   end
 
 end

--- a/spec/requests/locations/delivery_locations_json_view_spec.rb
+++ b/spec/requests/locations/delivery_locations_json_view_spec.rb
@@ -27,7 +27,8 @@ module Locations
             path: delivery_location_path(delivery_location, format: :json),
             library: {
               label: delivery_location.library.label,
-              code: delivery_location.library.code
+              code: delivery_location.library.code,
+              order: delivery_location.library.order
             }
           }
           expected << attrs
@@ -50,7 +51,8 @@ module Locations
           digital_location: delivery_location.digital_location,
           library: {
             label: delivery_location.library.label,
-            code: delivery_location.library.code
+            code: delivery_location.library.code,
+            order: delivery_location.library.order
           }
         }
         get delivery_location_path(delivery_location), format: :json

--- a/spec/requests/locations/holding_locations_json_view_spec.rb
+++ b/spec/requests/locations/holding_locations_json_view_spec.rb
@@ -27,7 +27,8 @@ module Locations
             path: holding_location_path(holding_location, format: :json),
             library: {
               label: holding_location.library.label,
-              code: holding_location.library.code
+              code: holding_location.library.code,
+              order: holding_location.library.order
             },
             holding_library: nil,
             hours_location: nil
@@ -51,11 +52,13 @@ module Locations
           path: holding_location_path(holding_location, format: :json),
           library: {
             label: holding_location.library.label,
-            code: holding_location.library.code
+            code: holding_location.library.code,
+            order: holding_location.library.order
           },
           holding_library: {
             label: holding_location.holding_library.label,
-            code: holding_location.holding_library.code
+            code: holding_location.holding_library.code,
+            order: holding_location.holding_library.order
           },
           hours_location: {
             label: holding_location.hours_location.label,
@@ -89,7 +92,8 @@ module Locations
           circulates: holding_location.circulates,
           library: {
             label: holding_location.library.label,
-            code: holding_location.library.code
+            code: holding_location.library.code,
+            order: holding_location.library.order
           },
           holding_library: nil,
           hours_location: nil
@@ -134,7 +138,8 @@ module Locations
           circulates: holding_location.circulates,
           library: {
             label: holding_location.library.label,
-            code: holding_location.library.code
+            code: holding_location.library.code,
+            order: holding_location.library.order
           },
           holding_library: nil,
           hours_location: {
@@ -181,11 +186,13 @@ module Locations
           circulates: holding_location.circulates,
           library: {
             label: holding_location.library.label,
-            code: holding_location.library.code
+            code: holding_location.library.code,
+            order: holding_location.library.order
           },
           holding_library: {
             label: holding_location.holding_library.label,
-            code: holding_location.holding_library.code
+            code: holding_location.holding_library.code,
+            order: holding_location.holding_library.order
           },
           hours_location: nil
         }

--- a/spec/requests/locations/libraries_json_view_spec.rb
+++ b/spec/requests/locations/libraries_json_view_spec.rb
@@ -11,19 +11,21 @@ module Locations
 
     describe 'the response body' do
 
-      it "/libraries looks as we'd expect" do
+      it "/libraries looks as we'd expect, sorted by order" do
         2.times { FactoryGirl.create(:library) }
         expected = []
         Library.all.each do |library|
           attrs = {
             label: library.label,
             code: library.code,
+            order: library.order,
             path: library_path(library, format: :json)
           }
           expected << attrs
         end
+        sorted = expected.sort_by { |l| [l[:order], l[:label]] }
         get libraries_path, format: :json
-        expect(response.body).to eq expected.to_json
+        expect(response.body).to eq sorted.to_json
 
       end
 
@@ -31,7 +33,8 @@ module Locations
         library = FactoryGirl.create(:library)
         expected = {
           label: library.label,
-          code: library.code
+          code: library.code,
+          order: library.order
         }
         get library_path(library), format: :json
         expect(response.body).to eq expected.to_json


### PR DESCRIPTION
 - Advances pulibrary/orangelight#327 by adding a sort order column for the libraries. Makes reordering easier with jquery tablesorter widget.
 - Makes master default branch in Readme. Closes #76. 
 - Carrierwave method name change. See https://github.com/carrierwaveuploader/carrierwave/issues/1896