### PR TITLE
Allow locator to accept call number parameter, rails 5.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: ruby
 rvm:
-  - 2.1.5
-  - 2.2.0
+  - 2.3.5
 
 script: bundle exec rake ci
 

--- a/app/assets/javascripts/locations/application.js
+++ b/app/assets/javascripts/locations/application.js
@@ -1,5 +1,5 @@
 //= require jquery
-//= require jquery_ujs
+//= require rails-ujs
 //= require bootstrap-sprockets
 //= require jquery-tablesorter
 //= require jquery-tablesorter/widgets/widget-editable

--- a/app/controllers/locations/map_controller.rb
+++ b/app/controllers/locations/map_controller.rb
@@ -4,21 +4,19 @@ module Locations
   class MapController < ApplicationController
 
     def index
-        @map = Map.new(id: map_params[:id],loc: map_params[:loc])
-
-        if @map.valid?
-          unless @map.on_reserve?
-            redirect_to @map.url
-          end
-        else
-          render plain: "Invalid parameters.", status: 400
+      @map = Map.new(id: map_params[:id],loc: map_params[:loc], callno: map_params[:callno])
+      if @map.valid?
+        unless @map.on_reserve?
+          redirect_to @map.url
         end
-
+      else
+        render plain: "Invalid parameters.", status: 400
+      end
     end
 
     # Only allow a trusted parameter "white list" through.
     def map_params
-      params.permit(:id, :loc)
+      params.permit(:id, :loc, :callno)
     end
 
   end

--- a/app/models/locations/delivery_location.rb
+++ b/app/models/locations/delivery_location.rb
@@ -3,7 +3,7 @@ module Locations
     include Locations::Labeled
     include Locations::WithLibrary
 
-    has_and_belongs_to_many :holding_locations, -> { uniq },
+    has_and_belongs_to_many :holding_locations, -> { distinct },
       class_name: 'Locations::HoldingLocation',
       join_table: 'locations_holdings_delivery',
       foreign_key: 'locations_holding_location_id',

--- a/app/models/locations/holding_location.rb
+++ b/app/models/locations/holding_location.rb
@@ -3,10 +3,10 @@ module Locations
     include Locations::Coded
     include Locations::WithLibrary
 
-    belongs_to :hours_location, class_name: 'Locations::HoursLocation', foreign_key: :locations_hours_location_id
-    belongs_to :holding_library, class_name: 'Locations::Library', foreign_key: :holding_library_id
+    belongs_to :hours_location, class_name: 'Locations::HoursLocation', foreign_key: :locations_hours_location_id, optional: true
+    belongs_to :holding_library, class_name: 'Locations::Library', foreign_key: :holding_library_id, optional: true
 
-    has_and_belongs_to_many :delivery_locations, -> { uniq },
+    has_and_belongs_to_many :delivery_locations, -> { distinct },
       class_name: 'Locations::DeliveryLocation',
       join_table: 'locations_holdings_delivery',
       foreign_key: 'locations_delivery_location_id',

--- a/db/migrate/20150519154738_create_locations_delivery_locations.rb
+++ b/db/migrate/20150519154738_create_locations_delivery_locations.rb
@@ -1,4 +1,4 @@
-class CreateLocationsDeliveryLocations < ActiveRecord::Migration
+class CreateLocationsDeliveryLocations < ActiveRecord::Migration[4.2]
   def change
     create_table :locations_delivery_locations do |t|
       t.string :label

--- a/db/migrate/20150520130710_create_locations_libraries.rb
+++ b/db/migrate/20150520130710_create_locations_libraries.rb
@@ -1,4 +1,4 @@
-class CreateLocationsLibraries < ActiveRecord::Migration
+class CreateLocationsLibraries < ActiveRecord::Migration[4.2]
   def change
     create_table :locations_libraries do |t|
       t.string :label

--- a/db/migrate/20150520175207_add_locations_library_to_locations_delivery_location.rb
+++ b/db/migrate/20150520175207_add_locations_library_to_locations_delivery_location.rb
@@ -1,4 +1,4 @@
-class AddLocationsLibraryToLocationsDeliveryLocation < ActiveRecord::Migration
+class AddLocationsLibraryToLocationsDeliveryLocation < ActiveRecord::Migration[4.2]
   def change
     add_reference :locations_delivery_locations, :locations_library, index: true, foreign_key: true
   end

--- a/db/migrate/20150521202558_create_locations_holding_locations.rb
+++ b/db/migrate/20150521202558_create_locations_holding_locations.rb
@@ -1,4 +1,4 @@
-class CreateLocationsHoldingLocations < ActiveRecord::Migration
+class CreateLocationsHoldingLocations < ActiveRecord::Migration[4.2]
   def change
     create_table :locations_holding_locations do |t|
       t.string :label

--- a/db/migrate/20150521203608_add_locations_library_to_locations_holding_location.rb
+++ b/db/migrate/20150521203608_add_locations_library_to_locations_holding_location.rb
@@ -1,4 +1,4 @@
-class AddLocationsLibraryToLocationsHoldingLocation < ActiveRecord::Migration
+class AddLocationsLibraryToLocationsHoldingLocation < ActiveRecord::Migration[4.2]
   def change
     add_reference :locations_holding_locations, :locations_library, index: true, foreign_key: true
   end

--- a/db/migrate/20150521221100_add_locations_holdings_delivery_join.rb
+++ b/db/migrate/20150521221100_add_locations_holdings_delivery_join.rb
@@ -1,4 +1,4 @@
-class AddLocationsHoldingsDeliveryJoin < ActiveRecord::Migration
+class AddLocationsHoldingsDeliveryJoin < ActiveRecord::Migration[4.2]
   def change
     create_table :locations_holdings_delivery, id: false do |t|
       t.integer :locations_delivery_location_id, index: false

--- a/db/migrate/20150522175704_add_additional_fields_to_holding_location.rb
+++ b/db/migrate/20150522175704_add_additional_fields_to_holding_location.rb
@@ -1,4 +1,4 @@
-class AddAdditionalFieldsToHoldingLocation < ActiveRecord::Migration
+class AddAdditionalFieldsToHoldingLocation < ActiveRecord::Migration[4.2]
   def change
     add_column :locations_holding_locations, :aeon_location, :boolean, default: false
     add_column :locations_holding_locations, :recap_electronic_delivery_location, :boolean, default: false

--- a/db/migrate/20150527211018_add_pickup_attr_to_delivery_location.rb
+++ b/db/migrate/20150527211018_add_pickup_attr_to_delivery_location.rb
@@ -1,4 +1,4 @@
-class AddPickupAttrToDeliveryLocation < ActiveRecord::Migration
+class AddPickupAttrToDeliveryLocation < ActiveRecord::Migration[4.2]
   def change
     add_column :locations_delivery_locations, :gfa_pickup, :string
     add_column :locations_delivery_locations, :pickup_location, :boolean, default: false

--- a/db/migrate/20150603170114_create_locations_hours_locations.rb
+++ b/db/migrate/20150603170114_create_locations_hours_locations.rb
@@ -1,4 +1,4 @@
-class CreateLocationsHoursLocations < ActiveRecord::Migration
+class CreateLocationsHoursLocations < ActiveRecord::Migration[4.2]
   def change
     create_table :locations_hours_locations do |t|
       t.string :code

--- a/db/migrate/20150603212708_add_hours_loc_to_locations_holding_locations.rb
+++ b/db/migrate/20150603212708_add_hours_loc_to_locations_holding_locations.rb
@@ -1,4 +1,4 @@
-class AddHoursLocToLocationsHoldingLocations < ActiveRecord::Migration
+class AddHoursLocToLocationsHoldingLocations < ActiveRecord::Migration[4.2]
   def change
     add_reference :locations_holding_locations, :locations_hours_location, foreign_key: true
   end

--- a/db/migrate/20160127140802_add_digital_location_to_delivery_location.rb
+++ b/db/migrate/20160127140802_add_digital_location_to_delivery_location.rb
@@ -1,4 +1,4 @@
-class AddDigitalLocationToDeliveryLocation < ActiveRecord::Migration
+class AddDigitalLocationToDeliveryLocation < ActiveRecord::Migration[4.2]
   def change
     add_column :locations_delivery_locations, :digital_location, :boolean
   end

--- a/db/migrate/20160127155209_set_digital_location.rb
+++ b/db/migrate/20160127155209_set_digital_location.rb
@@ -1,4 +1,4 @@
-class SetDigitalLocation < ActiveRecord::Migration
+class SetDigitalLocation < ActiveRecord::Migration[4.2]
   def change
     Locations::DeliveryLocation.update_all("digital_location=pickup_location")
   end

--- a/db/migrate/20160218152356_add_circulates_to_locations_holding_locations.rb
+++ b/db/migrate/20160218152356_add_circulates_to_locations_holding_locations.rb
@@ -1,4 +1,4 @@
-class AddCirculatesToLocationsHoldingLocations < ActiveRecord::Migration
+class AddCirculatesToLocationsHoldingLocations < ActiveRecord::Migration[4.2]
   def change
     add_column :locations_holding_locations, :circulates, :boolean, default: true
     reversible do |direction|

--- a/db/migrate/20160526020836_add_holding_library_to_locations_holding_library.rb
+++ b/db/migrate/20160526020836_add_holding_library_to_locations_holding_library.rb
@@ -1,4 +1,4 @@
-class AddHoldingLibraryToLocationsHoldingLibrary < ActiveRecord::Migration
+class AddHoldingLibraryToLocationsHoldingLibrary < ActiveRecord::Migration[4.2]
   def change
     add_column :locations_holding_locations, :holding_library_id, :integer, index: true
     add_foreign_key :locations_holding_locations, :locations_libraries, column: :holding_library_id

--- a/db/migrate/20160610203622_create_locations_floors.rb
+++ b/db/migrate/20160610203622_create_locations_floors.rb
@@ -1,4 +1,4 @@
-class CreateLocationsFloors < ActiveRecord::Migration
+class CreateLocationsFloors < ActiveRecord::Migration[4.2]
   def change
     create_table :locations_floors do |t|
       t.string :label

--- a/db/migrate/20160614154022_add_locations_library_to_locations_floors.rb
+++ b/db/migrate/20160614154022_add_locations_library_to_locations_floors.rb
@@ -1,4 +1,4 @@
-class AddLocationsLibraryToLocationsFloors < ActiveRecord::Migration
+class AddLocationsLibraryToLocationsFloors < ActiveRecord::Migration[4.2]
   def change
     add_reference :locations_floors, :locations_library, index: true, foreign_key: true
   end

--- a/db/migrate/20161228195737_add_order_to_locations_libraries.rb
+++ b/db/migrate/20161228195737_add_order_to_locations_libraries.rb
@@ -1,4 +1,4 @@
-class AddOrderToLocationsLibraries < ActiveRecord::Migration
+class AddOrderToLocationsLibraries < ActiveRecord::Migration[4.2]
   def change
     add_column :locations_libraries, :order, :integer, default: 0
   end

--- a/lib/generators/locations/install_generator.rb
+++ b/lib/generators/locations/install_generator.rb
@@ -6,7 +6,8 @@ module Locations
 
     def add_gems
       gem 'bootstrap-sass'
-      gem 'yaml_db', '~> 0.3.0'
+      gem 'yaml_db', '~> 0.6'
+      gem 'jquery-rails'
       Bundler.with_clean_env do
         run "bundle install"
       end
@@ -15,6 +16,10 @@ module Locations
     def friendly_id
       gem 'friendly_id', '~> 5.1.0'
       generate 'friendly_id'
+      migration_file =  Dir['db/migrate/*_create_friendly_id_slugs.rb'].first
+      inject_into_file migration_file, after: 'ActiveRecord::Migration' do
+        '[4.2]'
+      end
       gsub_file 'config/initializers/friendly_id.rb', 'new edit', 'create edit'
     end
 

--- a/lib/locations/version.rb
+++ b/lib/locations/version.rb
@@ -1,3 +1,3 @@
 module Locations
-  VERSION = "0.5.0"
+  VERSION = "1.0.0"
 end

--- a/locations.gemspec
+++ b/locations.gemspec
@@ -17,22 +17,23 @@ Gem::Specification.new do |s|
 
   s.files = Dir['{app,config,db,lib}/**/*', 'MIT-LICENSE', 'Rakefile', 'README.md']
 
-  s.add_dependency 'rails', '~> 4.2'
+  s.add_dependency 'rails', '~> 5.1'
   s.add_dependency 'bootstrap-sass', '~> 3.3'
   s.add_dependency 'friendly_id', '~> 5.1.0'
-  s.add_dependency 'yaml_db', '~> 0.3.0'
+  s.add_dependency 'yaml_db', '~> 0.6'
   s.add_dependency 'jquery-tablesorter', '~> 1.21'
   s.add_dependency 'rmagick'
   s.add_dependency 'carrierwave'
 
   s.add_development_dependency 'sqlite3'
   s.add_development_dependency 'rspec-rails', '~> 3.1'
-  s.add_development_dependency 'engine_cart', '~> 1.0'
+  s.add_development_dependency 'engine_cart', '~> 1.2'
   s.add_development_dependency 'factory_girl_rails', '~> 4.5.0'
   s.add_development_dependency 'faker', '~> 1.4.3'
   s.add_development_dependency 'database_cleaner', '~> 1.3'
-  s.add_development_dependency 'capybara', '~> 2.4.4'
+  s.add_development_dependency 'capybara', '~> 2.13'
   s.add_development_dependency 'poltergeist'
   s.add_development_dependency 'coveralls'
   s.add_development_dependency 'webmock'
+  s.add_development_dependency 'rails-controller-testing'
 end

--- a/spec/controllers/locations/delivery_locations_controller_spec.rb
+++ b/spec/controllers/locations/delivery_locations_controller_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 module Locations
-  describe DeliveryLocationsController, type: :controller do 
+  describe DeliveryLocationsController, type: :controller do
     routes { Locations::Engine.routes }
 
     let(:invalid_attributes) {
@@ -15,15 +15,15 @@ module Locations
 
       it 'assigns all delivery_locations as @delivery_locations' do
         delivery_location = FactoryGirl.create(:delivery_location)
-        get :index, {}, valid_session
+        get :index
         expect(assigns(:delivery_locations)).to eq([delivery_location])
       end
 
       it 'delivery_locations is active in navbar' do
-        get :index, {}, valid_session
-        expect(response.body.include?('<li class="active"><a href="/locations/delivery_locations')).to eq true       
+        get :index
+        expect(response.body.include?('<li class="active"><a href="/locations/delivery_locations')).to eq true
       end
-      
+
     end
 
     describe 'GET #digital_locations' do
@@ -32,7 +32,7 @@ module Locations
       it 'assigns only digital locations as @delivery_locations' do
         digital_location = FactoryGirl.create(:delivery_location, digital_location: true)
         analog_location = FactoryGirl.create(:delivery_location, digital_location: false)
-        get :digital_locations, {}, valid_session
+        get :digital_locations
         expect(assigns(:delivery_locations)).to eq([digital_location])
       end
 
@@ -41,14 +41,14 @@ module Locations
     describe 'GET #show' do
       it 'assigns the requested delivery_location as @delivery_location' do
         delivery_location = FactoryGirl.create(:delivery_location)
-        get :show, { id: delivery_location.to_param }, valid_session
+        get :show, params: { id: delivery_location.to_param }
         expect(assigns(:delivery_location)).to eq(delivery_location)
       end
     end
 
     describe 'GET #new' do
       it 'assigns a new delivery_location as @delivery_location' do
-        get :new, {}, valid_session
+        get :new
         expect(assigns(:delivery_location)).to be_a_new(DeliveryLocation)
       end
     end
@@ -56,7 +56,7 @@ module Locations
     describe 'GET #edit' do
       it 'assigns the requested delivery_location as @delivery_location' do
         delivery_location = FactoryGirl.create(:delivery_location)
-        get :edit, { id: delivery_location.to_param }, valid_session
+        get :edit, params: { id: delivery_location.to_param }
         expect(assigns(:delivery_location)).to eq(delivery_location)
       end
     end
@@ -71,23 +71,23 @@ module Locations
       context 'with valid params' do
         it 'creates a new DeliveryLocation' do
           expect {
-            post :create, { delivery_location: valid_attributes }, valid_session
+            post :create, params: { delivery_location: valid_attributes }
           }.to change(DeliveryLocation, :count).by(1)
         end
 
         it 'assigns a newly created delivery_location as @delivery_location' do
-          post :create, { delivery_location: valid_attributes }, valid_session
+          post :create, params: { delivery_location: valid_attributes }
           expect(assigns(:delivery_location)).to be_a(DeliveryLocation)
           expect(assigns(:delivery_location)).to be_persisted
         end
 
         it 'passes flash notice message' do
-          post :create, { delivery_location: valid_attributes }, valid_session
+          post :create, params: { delivery_location: valid_attributes }
           expect(flash[:notice]).to be_present
         end
 
         it 'redirects to the created delivery_location' do
-          post :create, { delivery_location: valid_attributes }, valid_session
+          post :create, params: { delivery_location: valid_attributes }
           expect(response).to redirect_to(DeliveryLocation.last)
         end
       end
@@ -95,17 +95,17 @@ module Locations
       context 'with invalid params' do
 
         it 'assigns a newly created but unsaved delivery_location as @delivery_location' do
-          post :create, { delivery_location: invalid_attributes }, valid_session
+          post :create, params: { delivery_location: invalid_attributes }
           expect(assigns(:delivery_location)).to be_a_new(DeliveryLocation)
         end
 
         it 'passes flash error message' do
-          post :create, { delivery_location: invalid_attributes }, valid_session
+          post :create, params: { delivery_location: invalid_attributes }
           expect(flash[:error]).to be_present
         end
 
         it 're-renders the "new" template' do
-          post :create, { delivery_location: invalid_attributes }, valid_session
+          post :create, params: { delivery_location: invalid_attributes }
           expect(response).to render_template('new')
         end
       end
@@ -120,26 +120,26 @@ module Locations
 
         it 'updates the requested delivery_location' do
           delivery_location = FactoryGirl.create(:delivery_location)
-          put :update, {:id => delivery_location.to_param, delivery_location: new_attributes }, valid_session
+          put :update, params: {:id => delivery_location.to_param, delivery_location: new_attributes }
           delivery_location.reload
           expect(delivery_location.label).to eq updated_label
         end
 
         it 'assigns the requested delivery_location as @delivery_location' do
           delivery_location = FactoryGirl.create(:delivery_location)
-          put :update, { :id => delivery_location.to_param, delivery_location: new_attributes }, valid_session
+          put :update, params: { :id => delivery_location.to_param, delivery_location: new_attributes }
           expect(assigns(:delivery_location)).to eq(delivery_location)
         end
 
         it 'passes flash notice message' do
           delivery_location = FactoryGirl.create(:delivery_location)
-          put :update, {:id => delivery_location.to_param, delivery_location: new_attributes }, valid_session
+          put :update, params: {:id => delivery_location.to_param, delivery_location: new_attributes }
           expect(flash[:notice]).to be_present
         end
 
         it 'redirects to the delivery_location' do
           delivery_location = FactoryGirl.create(:delivery_location)
-          put :update, {:id => delivery_location.to_param, delivery_location: new_attributes }, valid_session
+          put :update, params: {:id => delivery_location.to_param, delivery_location: new_attributes }
           expect(response).to redirect_to(delivery_location)
         end
       end
@@ -147,19 +147,19 @@ module Locations
       context 'with invalid params' do
         it 'assigns the delivery_location as @delivery_location' do
           delivery_location = FactoryGirl.create(:delivery_location)
-          put :update, {:id => delivery_location.to_param, delivery_location: invalid_attributes }, valid_session
+          put :update, params: {:id => delivery_location.to_param, delivery_location: invalid_attributes }
           expect(assigns(:delivery_location)).to eq(delivery_location)
         end
 
         it 'passes a flash error message' do
           delivery_location = FactoryGirl.create(:delivery_location)
-          put :update, {:id => delivery_location.to_param, delivery_location: invalid_attributes }, valid_session
+          put :update, params: {:id => delivery_location.to_param, delivery_location: invalid_attributes }
           expect(flash[:error]).to be_present
         end
 
         it 're-renders the "edit" template' do
           delivery_location = FactoryGirl.create(:delivery_location)
-          put :update, {:id => delivery_location.to_param, delivery_location: invalid_attributes }, valid_session
+          put :update, params: {:id => delivery_location.to_param, delivery_location: invalid_attributes }
           expect(response).to render_template('edit')
         end
       end
@@ -169,19 +169,19 @@ module Locations
       it 'destroys the requested delivery_location' do
         delivery_location = FactoryGirl.create(:delivery_location)
         expect {
-          delete :destroy, { id: delivery_location.to_param }, valid_session
+          delete :destroy, params: { id: delivery_location.to_param }
         }.to change(DeliveryLocation, :count).by(-1)
       end
 
       it 'passes flash notice message' do
         delivery_location = FactoryGirl.create(:delivery_location)
-        delete :destroy, { id: delivery_location.to_param }, valid_session
+        delete :destroy, params: { id: delivery_location.to_param }
         expect(flash[:notice]).to be_present
       end
 
       it 'redirects to the delivery_locations list' do
         delivery_location = FactoryGirl.create(:delivery_location)
-        delete :destroy, { id: delivery_location.to_param }, valid_session
+        delete :destroy, params: { id: delivery_location.to_param }
         expect(response).to redirect_to(delivery_locations_path)
       end
     end

--- a/spec/controllers/locations/floors_controller_spec.rb
+++ b/spec/controllers/locations/floors_controller_spec.rb
@@ -48,7 +48,7 @@ module Locations
 
       it "assigns all floors as @floors" do
         floor = Floor.create! valid_attributes
-        get :index, {:library_id => floor.locations_library_id, :id => floor.to_param}, valid_session
+        get :index, params: {:library_id => floor.locations_library_id, :id => floor.to_param}
         expect(assigns(:floors)).to eq([floor])
       end
 
@@ -57,7 +57,7 @@ module Locations
     describe "GET #show" do
       it "assigns the requested floor as @floor" do
         floor = Floor.create! valid_attributes
-        get :show, {:library_id => floor.locations_library_id, :id => floor.to_param}, valid_session
+        get :show, params: {:library_id => floor.locations_library_id, :id => floor.to_param}
         expect(assigns(:floor)).to eq(floor)
       end
     end
@@ -65,7 +65,7 @@ module Locations
     describe "GET #new" do
       it "assigns a new floor as @floor" do
         floor = Floor.create! valid_attributes
-        get :new, {:library_id => floor.locations_library_id, :id => floor.to_param}, valid_session
+        get :new, params: {:library_id => floor.locations_library_id, :id => floor.to_param}
         expect(assigns(:floor)).to be_a_new(Floor)
       end
     end
@@ -73,7 +73,7 @@ module Locations
     describe "GET #edit" do
       it "assigns the requested floor as @floor" do
         floor = Floor.create! valid_attributes
-        get :edit, {:library_id => floor.locations_library_id, :id => floor.to_param}, valid_session
+        get :edit, params: {:library_id => floor.locations_library_id, :id => floor.to_param}
         expect(assigns(:floor)).to eq(floor)
       end
     end
@@ -83,30 +83,30 @@ module Locations
       context "with valid params" do
         it "creates a new Floor" do
           expect {
-            post :create, {:library_id => valid_attributes[:locations_library_id], :floor => valid_attributes}, valid_session
+            post :create, params: {:library_id => valid_attributes[:locations_library_id], :floor => valid_attributes}
           }.to change(Floor, :count).by(1)
         end
 
         it "assigns a newly created floor as @floor" do
-          post :create, {:library_id => valid_attributes[:locations_library_id], :floor => valid_attributes}, valid_session
+          post :create, params: {:library_id => valid_attributes[:locations_library_id], :floor => valid_attributes}
           expect(assigns(:floor)).to be_a(Floor)
           expect(assigns(:floor)).to be_persisted
         end
 
         it "redirects to the created floor" do
-          post :create, {:library_id => valid_attributes[:locations_library_id], :floor => valid_attributes}, valid_session
+          post :create, params: {:library_id => valid_attributes[:locations_library_id], :floor => valid_attributes}
           expect(response).to redirect_to(library_floor_path(valid_attributes[:locations_library_id], Floor.last))
         end
       end
 
       context "with invalid params" do
         it "assigns a newly created but unsaved floor as @floor" do
-          post :create, {:library_id => valid_attributes[:locations_library_id], :floor => invalid_attributes}, valid_session
+          post :create, params: {:library_id => valid_attributes[:locations_library_id], :floor => invalid_attributes}
           expect(assigns(:floor)).to be_a_new(Floor)
         end
 
         it "re-renders the 'new' template" do
-          post :create, {:library_id => valid_attributes[:locations_library_id], :floor => invalid_attributes}, valid_session
+          post :create, params: {:library_id => valid_attributes[:locations_library_id], :floor => invalid_attributes}
           expect(response).to render_template("new")
         end
       end
@@ -124,19 +124,19 @@ module Locations
 
         it "updates the requested floor" do
           floor = Floor.create! valid_attributes
-          put :update, {:library_id => new_attributes[:locations_library_id], :id => floor.to_param, :floor => new_attributes}, valid_session
+          put :update, params: {:library_id => new_attributes[:locations_library_id], :id => floor.to_param, :floor => new_attributes}
           floor.reload
         end
 
         it "assigns the requested floor as @floor" do
           floor = Floor.create! valid_attributes
-          put :update, {:library_id => valid_attributes[:locations_library_id], :id => floor.to_param, :floor => valid_attributes}, valid_session
+          put :update, params: {:library_id => valid_attributes[:locations_library_id], :id => floor.to_param, :floor => valid_attributes}
           expect(assigns(:floor)).to eq(floor)
         end
 
         it "redirects to the floor" do
           floor = Floor.create! valid_attributes
-          put :update, {:library_id => valid_attributes[:locations_library_id], :id => floor.to_param, :floor => valid_attributes}, valid_session
+          put :update, params: {:library_id => valid_attributes[:locations_library_id], :id => floor.to_param, :floor => valid_attributes}
           expect(response).to redirect_to(library_floor_path(valid_attributes[:locations_library_id], floor))
         end
       end
@@ -144,13 +144,13 @@ module Locations
       context "with invalid params" do
         it "assigns the floor as @floor" do
           floor = Floor.create! valid_attributes
-          put :update, {:library_id => valid_attributes[:locations_library_id], :id => floor.to_param, :floor => invalid_attributes}, valid_session
+          put :update, params: {:library_id => valid_attributes[:locations_library_id], :id => floor.to_param, :floor => invalid_attributes}
           expect(assigns(:floor)).to eq(floor)
         end
 
         it "re-renders the 'edit' template" do
           floor = Floor.create! valid_attributes
-          put :update, {:library_id => valid_attributes[:locations_library_id], :id => floor.to_param, :floor => invalid_attributes}, valid_session
+          put :update, params: {:library_id => valid_attributes[:locations_library_id], :id => floor.to_param, :floor => invalid_attributes}
           expect(response).to render_template("edit")
         end
       end
@@ -160,13 +160,13 @@ module Locations
       it "destroys the requested floor" do
         floor = Floor.create! valid_attributes
         expect {
-          delete :destroy, {:library_id => valid_attributes[:locations_library_id], :id => floor.to_param}, valid_session
+          delete :destroy, params: {:library_id => valid_attributes[:locations_library_id], :id => floor.to_param}
         }.to change(Floor, :count).by(-1)
       end
 
       it "redirects to the floors list" do
         floor = Floor.create! valid_attributes
-        delete :destroy, {:library_id => valid_attributes[:locations_library_id], :id => floor.to_param}, valid_session
+        delete :destroy, params: {:library_id => valid_attributes[:locations_library_id], :id => floor.to_param}
         expect(response).to redirect_to(library_floors_path(valid_attributes[:locations_library_id]))
       end
     end

--- a/spec/controllers/locations/holding_locations_controller_spec.rb
+++ b/spec/controllers/locations/holding_locations_controller_spec.rb
@@ -16,28 +16,28 @@ module Locations
 
       it "assigns all holding_locations as @holding_locations" do
         holding_location = FactoryGirl.create(:holding_location)
-        get :index, {}, valid_session
+        get :index
         expect(assigns(:holding_locations)).to eq([holding_location])
       end
 
       it 'holding_locations is active in navbar' do
-        get :index, {}, valid_session
-        expect(response.body.include?('<li class="active"><a href="/locations/holding_locations')).to eq true       
-      end      
-      
+        get :index
+        expect(response.body.include?('<li class="active"><a href="/locations/holding_locations')).to eq true
+      end
+
     end
 
     describe "GET #show" do
       it "assigns the requested holding_location as @holding_location" do
         holding_location = FactoryGirl.create(:holding_location)
-        get :show, { id: holding_location.code }, valid_session
+        get :show, params: { id: holding_location.code }
         expect(assigns(:holding_location)).to eq(holding_location)
       end
     end
 
     describe "GET #new" do
       it "assigns a new holding_location as @holding_location" do
-        get :new, {}, valid_session
+        get :new
         expect(assigns(:holding_location)).to be_a_new(HoldingLocation)
       end
     end
@@ -45,7 +45,7 @@ module Locations
     describe "GET #edit" do
       it "assigns the requested holding_location as @holding_location" do
         holding_location = FactoryGirl.create(:holding_location)
-        get :edit, { id: holding_location.code }, valid_session
+        get :edit, params: { id: holding_location.code }
         expect(assigns(:holding_location)).to eq(holding_location)
       end
     end
@@ -60,40 +60,40 @@ module Locations
       context "with valid params" do
         it "creates a new HoldingLocation" do
           expect {
-            post :create, { holding_location: valid_attributes }, valid_session
+            post :create, params: { holding_location: valid_attributes }
           }.to change(HoldingLocation, :count).by(1)
         end
 
         it "assigns a newly created holding_location as @holding_location" do
-          post :create, { holding_location: valid_attributes }, valid_session
+          post :create, params: { holding_location: valid_attributes }
           expect(assigns(:holding_location)).to be_a(HoldingLocation)
           expect(assigns(:holding_location)).to be_persisted
         end
 
         it 'passes flash notice message' do
-          post :create, { holding_location: valid_attributes }, valid_session
+          post :create, params: { holding_location: valid_attributes }
           expect(flash[:notice]).to be_present
-        end        
+        end
 
         it "redirects to the created holding_location" do
-          post :create, { holding_location: valid_attributes }, valid_session
+          post :create, params: { holding_location: valid_attributes }
           expect(response).to redirect_to(HoldingLocation.last)
         end
       end
 
       context "with invalid params" do
         it "assigns a newly created but unsaved holding_location as @holding_location" do
-          post :create, {holding_location: invalid_attributes }, valid_session
+          post :create, params: { holding_location: invalid_attributes }
           expect(assigns(:holding_location)).to be_a_new(HoldingLocation)
         end
 
         it 'passes a flash error message' do
-          post :create, {holding_location: invalid_attributes }, valid_session
+          post :create, params: { holding_location: invalid_attributes }
           expect(flash[:error]).to be_present
-        end        
+        end
 
         it "re-renders the 'new' template" do
-          post :create, {holding_location: invalid_attributes }, valid_session
+          post :create, params: { holding_location: invalid_attributes }
           expect(response).to render_template("new")
         end
       end
@@ -107,48 +107,48 @@ module Locations
         FactoryGirl.attributes_for(:holding_location, opts)
       }
       let(:valid_params) {
-        { id: holding_location.code, holding_location: new_attributes }
+        { params: { id: holding_location.code, holding_location: new_attributes } }
       }
       let(:invalid_params) {
-        { id: holding_location.code, holding_location: invalid_attributes}
+        { params: { id: holding_location.code, holding_location: invalid_attributes} }
       }
       context "with valid params" do
 
         it "updates the requested holding_location" do
-          put :update, valid_params, valid_session
+          put :update, valid_params
           holding_location.reload
           expect(holding_location.label).to eq updated_label
         end
 
         it "assigns the requested holding_location as @holding_location" do
-          put :update, valid_params, valid_session
+          put :update, valid_params
           expect(assigns(:holding_location)).to eq(holding_location)
         end
 
         it 'passes flash notice message' do
-          put :update, valid_params, valid_session
+          put :update, valid_params
           expect(flash[:notice]).to be_present
         end
 
         it "redirects to the holding_location" do
-          put :update, valid_params, valid_session
+          put :update, valid_params
           expect(response).to redirect_to(holding_location)
         end
       end
 
       context "with invalid params" do
         it "assigns the holding_location as @holding_location" do
-          put :update, invalid_params, valid_session
+          put :update, invalid_params
           expect(assigns(:holding_location)).to eq(holding_location)
         end
 
         it 'passes a flash error message' do
-          put :update, invalid_params, valid_session
+          put :update, invalid_params
           expect(flash[:error]).to be_present
-        end        
+        end
 
         it "re-renders the 'edit' template" do
-          put :update, invalid_params, valid_session
+          put :update, invalid_params
           expect(response).to render_template("edit")
         end
       end
@@ -158,19 +158,19 @@ module Locations
       it "destroys the requested holding_location" do
         holding_location = FactoryGirl.create(:holding_location)
         expect {
-          delete :destroy, { id: holding_location.code }, valid_session
+          delete :destroy, params: { id: holding_location.code }
         }.to change(HoldingLocation, :count).by(-1)
       end
 
       it 'passes flash notice message' do
         holding_location = FactoryGirl.create(:holding_location)
-        delete :destroy, { id: holding_location.code }, valid_session
+        delete :destroy, params: { id: holding_location.code }
         expect(flash[:notice]).to be_present
       end
 
       it "redirects to the holding_locations list" do
         holding_location = FactoryGirl.create(:holding_location)
-        delete :destroy, { id: holding_location.code }, valid_session
+        delete :destroy, params: { id: holding_location.code }
         expect(response).to redirect_to(holding_locations_path)
       end
     end

--- a/spec/controllers/locations/home_controller_spec.rb
+++ b/spec/controllers/locations/home_controller_spec.rb
@@ -10,7 +10,7 @@ module Locations
       render_views
 
       it 'location homepage is active in navbar' do
-        get :index, {}, valid_session
+        get :index
         expect(response.body.include?('<li class="active"><a href="/locations/')).to eq true       
       end
 

--- a/spec/controllers/locations/hours_locations_controller_spec.rb
+++ b/spec/controllers/locations/hours_locations_controller_spec.rb
@@ -16,12 +16,12 @@ module Locations
 
       it "assigns all hours_locations as @hours_locations" do
         hours_location = FactoryGirl.create(:hours_location)
-        get :index, {}, valid_session
+        get :index
         expect(assigns(:hours_locations)).to eq([hours_location])
       end
-      
+
       it 'hours_locations is active in navbar' do
-        get :index, {}, valid_session
+        get :index
         expect(response.body.include?('<li class="active"><a href="/locations/hours_locations')).to eq true
       end
 
@@ -30,14 +30,14 @@ module Locations
     describe "GET #show" do
       it "assigns the requested hours_location as @hours_location" do
         hours_location = FactoryGirl.create(:hours_location)
-        get :show, { id: hours_location.code}, valid_session
+        get :show, params: { id: hours_location.code}
         expect(assigns(:hours_location)).to eq(hours_location)
       end
     end
 
     describe "GET #new" do
       it "assigns a new hours_location as @hours_location" do
-        get :new, {}, valid_session
+        get :new
         expect(assigns(:hours_location)).to be_a_new(HoursLocation)
       end
     end
@@ -45,51 +45,51 @@ module Locations
     describe "GET #edit" do
       it "assigns the requested hours_location as @hours_location" do
         hours_location = FactoryGirl.create(:hours_location)
-        get :edit, { id: hours_location.code}, valid_session
+        get :edit, params: { id: hours_location.code}
         expect(assigns(:hours_location)).to eq(hours_location)
       end
     end
 
     describe "POST #create" do
-      let(:valid_params) { { hours_location: FactoryGirl.attributes_for(:hours_location) } }
-      let(:invalid_params) { {hours_location: invalid_attributes} }
+      let(:valid_params) { { params: { hours_location: FactoryGirl.attributes_for(:hours_location) } } }
+      let(:invalid_params) { { params: {hours_location: invalid_attributes} } }
       context "with valid params" do
         it "creates a new hours_location" do
           expect {
-            post :create, valid_params, valid_session
+            post :create, valid_params
           }.to change(HoursLocation, :count).by(1)
         end
 
         it "assigns a newly created hours_location as @hours_location" do
-          post :create, valid_params, valid_session
+          post :create, valid_params
           expect(assigns(:hours_location)).to be_a(HoursLocation)
           expect(assigns(:hours_location)).to be_persisted
         end
 
         it 'passes flash notice message' do
-          post :create, valid_params, valid_session
+          post :create, valid_params
           expect(flash[:notice]).to be_present
-        end              
+        end
 
         it "redirects to the created hours_location" do
-          post :create, valid_params, valid_session
+          post :create, valid_params
           expect(response).to redirect_to(HoursLocation.last)
         end
       end
 
       context "with invalid params" do
         it "assigns a newly created but unsaved hours_location as @hours_location" do
-          post :create, invalid_params, valid_session
+          post :create, invalid_params
           expect(assigns(:hours_location)).to be_a_new(HoursLocation)
         end
 
         it 'passes a flash error message' do
-          post :create, invalid_params, valid_session
+          post :create, invalid_params
           expect(flash[:error]).to be_present
-        end        
-        
+        end
+
         it "re-renders the 'new' template" do
-          post :create, invalid_params, valid_session
+          post :create, invalid_params
           expect(response).to render_template("new")
         end
       end
@@ -102,44 +102,44 @@ module Locations
         opts = { label: updated_label, code: hours_location.code }
         FactoryGirl.attributes_for(:hours_location, opts)
       }
-      let(:valid_params) { { id: hours_location.code, hours_location: new_attributes } }
-      let(:invalid_params) { { id: hours_location.code, hours_location: invalid_attributes} }
+      let(:valid_params) { { params: { id: hours_location.code, hours_location: new_attributes } } }
+      let(:invalid_params) { { params: { id: hours_location.code, hours_location: invalid_attributes} } }
       context "with valid params" do
         it "updates the requested hours_location" do
-          put :update, valid_params, valid_session
+          put :update, valid_params
           hours_location.reload
           expect(hours_location.label).to eq updated_label
         end
 
         it "assigns the requested hours_location as @hours_location" do
-          put :update, valid_params, valid_session
+          put :update, valid_params
           expect(assigns(:hours_location)).to eq(hours_location)
         end
 
         it 'passes flash notice message' do
-          put :update, valid_params, valid_session
+          put :update, valid_params
           expect(flash[:notice]).to be_present
-        end        
+        end
 
         it "redirects to the hours_location" do
-          put :update, valid_params, valid_session
+          put :update, valid_params
           expect(response).to redirect_to(hours_location)
         end
       end
 
       context "with invalid params" do
         it "assigns the hours_location as @hours_location" do
-          put :update, invalid_params, valid_session
+          put :update, invalid_params
           expect(assigns(:hours_location)).to eq(hours_location)
         end
 
         it 'passes a flash error message' do
-          put :update, invalid_params, valid_session
+          put :update, invalid_params
           expect(flash[:error]).to be_present
-        end        
+        end
 
         it "re-renders the 'edit' template" do
-          put :update, invalid_params, valid_session
+          put :update, invalid_params
           expect(response).to render_template("edit")
         end
       end
@@ -149,19 +149,19 @@ module Locations
       it "destroys the requested hours_location" do
         hours_location = FactoryGirl.create(:hours_location)
         expect {
-          delete :destroy, { id: hours_location.code }, valid_session
+          delete :destroy, params: { id: hours_location.code }
         }.to change(HoursLocation, :count).by(-1)
       end
 
       it 'passes flash notice message' do
         hours_location = FactoryGirl.create(:hours_location)
-        delete :destroy, { id: hours_location.code }, valid_session
+        delete :destroy, params: { id: hours_location.code }
         expect(flash[:notice]).to be_present
       end
 
       it "redirects to the hours_locations list" do
         hours_location = FactoryGirl.create(:hours_location)
-        delete :destroy, { id: hours_location.code }, valid_session
+        delete :destroy, params: { id: hours_location.code }
         expect(response).to redirect_to(hours_locations_path)
       end
     end

--- a/spec/controllers/locations/libraries_controller_spec.rb
+++ b/spec/controllers/locations/libraries_controller_spec.rb
@@ -16,12 +16,12 @@ module Locations
 
       it "assigns all libraries as @libraries" do
         library = FactoryGirl.create(:library)
-        get :index, {}, valid_session
+        get :index
         expect(assigns(:libraries)).to eq([library])
       end
-      
+
       it 'libraries is active in navbar' do
-        get :index, {}, valid_session
+        get :index
         expect(response.body.include?('<li class="active"><a href="/locations/libraries')).to eq true
       end
 
@@ -30,14 +30,14 @@ module Locations
     describe "GET #show" do
       it "assigns the requested library as @library" do
         library = FactoryGirl.create(:library)
-        get :show, { id: library.code}, valid_session
+        get :show, params: { id: library.code}
         expect(assigns(:library)).to eq(library)
       end
     end
 
     describe "GET #new" do
       it "assigns a new library as @library" do
-        get :new, {}, valid_session
+        get :new
         expect(assigns(:library)).to be_a_new(Library)
       end
     end
@@ -45,51 +45,51 @@ module Locations
     describe "GET #edit" do
       it "assigns the requested library as @library" do
         library = FactoryGirl.create(:library)
-        get :edit, { id: library.code}, valid_session
+        get :edit, params: { id: library.code}
         expect(assigns(:library)).to eq(library)
       end
     end
 
     describe "POST #create" do
-      let(:valid_params) { { library: FactoryGirl.attributes_for(:library) } }
-      let(:invalid_params) { {library: invalid_attributes} }
+      let(:valid_params) { { params: { library: FactoryGirl.attributes_for(:library) } } }
+      let(:invalid_params) { { params: {library: invalid_attributes} } }
       context "with valid params" do
         it "creates a new Library" do
           expect {
-            post :create, valid_params, valid_session
+            post :create, valid_params
           }.to change(Library, :count).by(1)
         end
 
         it "assigns a newly created library as @library" do
-          post :create, valid_params, valid_session
+          post :create, valid_params
           expect(assigns(:library)).to be_a(Library)
           expect(assigns(:library)).to be_persisted
         end
 
         it 'passes flash notice message' do
-          post :create, valid_params, valid_session
+          post :create, valid_params
           expect(flash[:notice]).to be_present
-        end              
+        end
 
         it "redirects to the created library" do
-          post :create, valid_params, valid_session
+          post :create, valid_params
           expect(response).to redirect_to(Library.last)
         end
       end
 
       context "with invalid params" do
         it "assigns a newly created but unsaved library as @library" do
-          post :create, invalid_params, valid_session
+          post :create, invalid_params
           expect(assigns(:library)).to be_a_new(Library)
         end
 
         it 'passes a flash error message' do
-          post :create, invalid_params, valid_session
+          post :create, invalid_params
           expect(flash[:error]).to be_present
-        end        
-        
+        end
+
         it "re-renders the 'new' template" do
-          post :create, invalid_params, valid_session
+          post :create, invalid_params
           expect(response).to render_template("new")
         end
       end
@@ -102,34 +102,34 @@ module Locations
         opts = { label: updated_label, code: library.code }
         FactoryGirl.attributes_for(:library, opts)
       }
-      let(:valid_params) { { id: library.code, library: new_attributes } }
-      let(:invalid_params) { { id: library.code, library: invalid_attributes} }
+      let(:valid_params) { { params: { id: library.code, library: new_attributes } } }
+      let(:invalid_params) { { params: { id: library.code, library: invalid_attributes} } }
       context "with valid params" do
         it "updates the requested library" do
-          put :update, valid_params, valid_session
+          put :update, valid_params
           library.reload
           expect(library.label).to eq updated_label
         end
 
         it "assigns the requested library as @library" do
-          put :update, valid_params, valid_session
+          put :update, valid_params
           expect(assigns(:library)).to eq(library)
         end
 
         it 'passes flash notice message' do
-          put :update, valid_params, valid_session
+          put :update, valid_params
           expect(flash[:notice]).to be_present
-        end        
+        end
 
         it "redirects to the library" do
-          put :update, valid_params, valid_session
+          put :update, valid_params
           expect(response).to redirect_to(library)
         end
       end
 
       context "using ajax" do
         let(:updated_order) { 15 }
-        let(:ajax_params) { { order: updated_order, id: library.id, format: :js } }
+        let(:ajax_params) { { params: { order: updated_order, id: library.id, format: :js } } }
         it "updates the requested library's order" do
           original_order = library[:order]
           expect {
@@ -140,17 +140,17 @@ module Locations
 
       context "with invalid params" do
         it "assigns the library as @library" do
-          put :update, invalid_params, valid_session
+          put :update, invalid_params
           expect(assigns(:library)).to eq(library)
         end
 
         it 'passes a flash error message' do
-          put :update, invalid_params, valid_session
+          put :update, invalid_params
           expect(flash[:error]).to be_present
-        end        
+        end
 
         it "re-renders the 'edit' template" do
-          put :update, invalid_params, valid_session
+          put :update, invalid_params
           expect(response).to render_template("edit")
         end
       end
@@ -160,19 +160,19 @@ module Locations
       it "destroys the requested library" do
         library = FactoryGirl.create(:library)
         expect {
-          delete :destroy, { id: library.code }, valid_session
+          delete :destroy, params: { id: library.code }
         }.to change(Library, :count).by(-1)
       end
 
       it 'passes flash notice message' do
         library = FactoryGirl.create(:library)
-        delete :destroy, { id: library.code }, valid_session
+        delete :destroy, params: { id: library.code }
         expect(flash[:notice]).to be_present
       end
 
       it "redirects to the libraries list" do
         library = FactoryGirl.create(:library)
-        delete :destroy, { id: library.code }, valid_session
+        delete :destroy, params: { id: library.code }
         expect(response).to redirect_to(libraries_path)
       end
     end

--- a/spec/controllers/locations/map_controller_spec.rb
+++ b/spec/controllers/locations/map_controller_spec.rb
@@ -18,21 +18,27 @@ module Locations
 
         it 'redirects to the locator url' do
           get :index, params
-          expect(response).to redirect_to("http://library.princeton.edu/locator/index.php?loc=#{map.loc}&id=#{map.id}")
+          expect(response).to redirect_to("https://library.princeton.edu/locator/index.php?loc=#{map.loc}&id=#{map.id}")
         end
       end
 
       context 'with stackmap params' do
         let(:id) { '9547751' }
         let(:loc) { holding_location.code }
-        let(:callno) { map.bibrec['call_number_display'].first }
+        let(:bibdata_callno) { map.bibrec['call_number_display'].first }
+        let(:callno) { 'B15' }
         let(:holding_location) { FactoryGirl.create(:holding_location_stackmap, library_args: { code: 'lewis' }) }
 
         before { stub_request(:get, map_bibdata).to_return(status: 200, body: fixture('stackmap_bibrec.json')) }
 
-        it 'redirects to the stackmap url' do
+        it 'redirects to the stackmap url with provided call number param' do
+          params[:params][:callno] = callno
           get :index, params
-          expect(response).to redirect_to(URI.encode("http://princeton.stackmap.com/view/?callno=#{callno}&location=#{map.loc}&library=#{map.lib.label}"))
+          expect(response).to redirect_to(URI.encode("https://princeton.stackmap.com/view/?callno=#{callno}&location=#{map.loc}&library=#{map.lib.label}"))
+        end
+        it 'redirects to the stackmap url with bibdata call number when not provided' do
+          get :index, params
+          expect(response).to redirect_to(URI.encode("https://princeton.stackmap.com/view/?callno=#{bibdata_callno}&location=#{map.loc}&library=#{map.lib.label}"))
         end
       end
 

--- a/spec/controllers/locations/map_controller_spec.rb
+++ b/spec/controllers/locations/map_controller_spec.rb
@@ -4,7 +4,7 @@ module Locations
   describe MapController, type: :controller do
     routes { Locations::Engine.routes }
 
-    let(:params) { { id: id, loc: loc } }
+    let(:params) { { params: { id: id, loc: loc } } }
     let(:map) { Locations::Map.new(id: id, loc: loc) }
     let(:map_bibdata) { "https://bibdata.princeton.edu/bibliographic/#{map.id}/solr" }
 
@@ -17,7 +17,7 @@ module Locations
         before { stub_request(:get, map_bibdata).to_return(status: 200, body: fixture('locator_bibrec.json')) }
 
         it 'redirects to the locator url' do
-          get :index, params, {}
+          get :index, params
           expect(response).to redirect_to("http://library.princeton.edu/locator/index.php?loc=#{map.loc}&id=#{map.id}")
         end
       end
@@ -31,7 +31,7 @@ module Locations
         before { stub_request(:get, map_bibdata).to_return(status: 200, body: fixture('stackmap_bibrec.json')) }
 
         it 'redirects to the stackmap url' do
-          get :index, params, {}
+          get :index, params
           expect(response).to redirect_to(URI.encode("http://princeton.stackmap.com/view/?callno=#{callno}&location=#{map.loc}&library=#{map.lib.label}"))
         end
       end
@@ -44,7 +44,7 @@ module Locations
         before { stub_request(:get, map_bibdata).to_return(status: 200, body: '{}') }
 
         it 'returns a message to user via index template' do
-          get :index, params, {}
+          get :index, params
           expect(response).to render_template(:index)
         end
       end
@@ -54,7 +54,7 @@ module Locations
         let(:loc) { 'Bar!' }
 
         it 'returns an Bad Request 400 error' do
-          get :index, params, {}
+          get :index, params
           expect(response.status).to eq 400
         end
       end
@@ -63,7 +63,7 @@ module Locations
         let(:params) { {} }
 
         it 'returns an Bad Request 400 error' do
-          get :index, params, {}
+          get :index, params
           expect(response.status).to eq 400
         end
       end

--- a/spec/factories/locations/floors.rb
+++ b/spec/factories/locations/floors.rb
@@ -3,7 +3,7 @@ require 'faker'
 FactoryGirl.define do
   factory :floor, class: 'Locations::Floor' do
     label { 'Floor ' + Faker::Number.number(10).to_s }
-    floor_plan_image Rack::Test::UploadedFile.new(File.open(File.join(Rails.root, '/public/uploads/floorplan.png')))
+    floor_plan_image Rack::Test::UploadedFile.new('.internal_test_app/public/uploads/floorplan.png')
     starting_point "10,10,10,10"
     walkable_areas "<svg></svg>"
     library

--- a/spec/requests/locations/delivery_locations_json_view_spec.rb
+++ b/spec/requests/locations/delivery_locations_json_view_spec.rb
@@ -4,7 +4,7 @@ module Locations
   describe 'DeliveryLocation json view', type: :request do
 
     it 'Renders the json template' do
-      get delivery_locations_path, format: :json
+      get delivery_locations_path, params: { format: :json }
       expect(response).to render_template(:index)
       expect(response.content_type).to eq 'application/json'
     end
@@ -33,7 +33,7 @@ module Locations
           }
           expected << attrs
         end
-        get delivery_locations_path, format: :json
+        get delivery_locations_path, params: { format: :json }
         expect(response.body).to eq expected.to_json
 
       end
@@ -55,7 +55,7 @@ module Locations
             order: delivery_location.library.order
           }
         }
-        get delivery_location_path(delivery_location), format: :json
+        get delivery_location_path(delivery_location), params: { format: :json }
         expect(response.body).to eq expected.to_json
       end
 

--- a/spec/requests/locations/holding_locations_json_view_spec.rb
+++ b/spec/requests/locations/holding_locations_json_view_spec.rb
@@ -4,7 +4,7 @@ module Locations
   describe 'HoldingLocation json view', type: :request do
 
     it 'Renders the json template' do
-      get holding_locations_path, format: :json
+      get holding_locations_path, params: { format: :json }
       expect(response).to render_template(:index)
       expect(response.content_type).to eq 'application/json'
     end
@@ -66,7 +66,7 @@ module Locations
           }
         }
         expected << attrs
-        get holding_locations_path, format: :json
+        get holding_locations_path, params: { format: :json }
         expect(response.body).to eq expected.sort_by{ |k| k[:code] }.to_json
 
       end
@@ -112,7 +112,7 @@ module Locations
               digital_location: dl.digital_location
             }
         end
-        get holding_location_path(holding_location), format: :json
+        get holding_location_path(holding_location), params: { format: :json }
         expect(response.body).to eq expected.to_json
       end
 
@@ -161,7 +161,7 @@ module Locations
               digital_location: dl.digital_location
             }
         end
-        get holding_location_path(holding_location), format: :json
+        get holding_location_path(holding_location), params: { format: :json }
         expect(response.body).to eq expected.to_json
       end
       it "/holding_locations/{code} looks as we'd expect with holding_library" do
@@ -210,7 +210,7 @@ module Locations
               digital_location: dl.digital_location
             }
         end
-        get holding_location_path(holding_location), format: :json
+        get holding_location_path(holding_location), params: { format: :json }
         expect(response.body).to eq expected.to_json
       end
     end

--- a/spec/requests/locations/hours_locations_json_view_spec.rb
+++ b/spec/requests/locations/hours_locations_json_view_spec.rb
@@ -4,7 +4,7 @@ module Locations
   describe 'HoursLocation json view', type: :request do
 
     it 'Renders the json template' do
-      get hours_locations_path, format: :json
+      get hours_locations_path, params: { format: :json }
       expect(response).to render_template(:index)
       expect(response.content_type).to eq 'application/json'
     end
@@ -22,9 +22,8 @@ module Locations
           }
           expected << attrs
         end
-        get hours_locations_path, format: :json
+        get hours_locations_path, params: { format: :json }
         expect(response.body).to eq expected.to_json
-
       end
 
       it "/hours_locations/{code} looks as we'd expect" do
@@ -33,7 +32,7 @@ module Locations
           label: hours_location.label,
           code: hours_location.code
         }
-        get hours_location_path(hours_location), format: :json
+        get hours_location_path(hours_location), params: { format: :json }
         expect(response.body).to eq expected.to_json
       end
 

--- a/spec/requests/locations/libraries_json_view_spec.rb
+++ b/spec/requests/locations/libraries_json_view_spec.rb
@@ -4,7 +4,7 @@ module Locations
   describe 'Library json view', type: :request do
 
     it 'Renders the json template' do
-      get libraries_path, format: :json
+      get libraries_path, params: { format: :json }
       expect(response).to render_template(:index)
       expect(response.content_type).to eq 'application/json'
     end
@@ -24,7 +24,7 @@ module Locations
           expected << attrs
         end
         sorted = expected.sort_by { |l| [l[:order], l[:label]] }
-        get libraries_path, format: :json
+        get libraries_path, params: { format: :json }
         expect(response.body).to eq sorted.to_json
 
       end
@@ -36,7 +36,7 @@ module Locations
           code: library.code,
           order: library.order
         }
-        get library_path(library), format: :json
+        get library_path(library), params: { format: :json }
         expect(response.body).to eq expected.to_json
       end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,6 +13,8 @@ require 'rspec/rails'
 require 'engine_cart'
 require 'database_cleaner'
 require 'capybara/poltergeist'
+require 'rails-controller-testing'
+Rails::Controller::Testing.install
 
 Capybara.javascript_driver = :poltergeist
 


### PR DESCRIPTION
Closes #78. With this change the voyager bib record only gets called for the stackmap locations that are sorted by title (less than 7000 titles) or if the call number parameter isn't provided.