### PR TITLE
return 400 unless a call number or valid voyager id param is passed

### DIFF
--- a/app/models/locations/map.rb
+++ b/app/models/locations/map.rb
@@ -70,7 +70,7 @@ module Locations
     end
 
     def valid?
-      !holding_location.nil?
+      !holding_location.nil? && (cn || !bibrec.empty?)
     end
 
     def on_reserve?
@@ -80,13 +80,14 @@ module Locations
     private
 
     def fetch_bibrec
+      return {} unless id
       url = "https://bibdata.princeton.edu/bibliographic/#{id}/solr"
       uri = URI.parse(url)
       http = Net::HTTP.new(uri.host, uri.port)
       http.use_ssl = true
       request = Net::HTTP::Get.new(uri.request_uri)
       res = http.request(request)
-      res.code == '200' ? JSON.parse(res.body) : ''
+      res.code == '200' ? JSON.parse(res.body) : {}
     end
 
     def fetch_hours_location

--- a/spec/controllers/locations/map_controller_spec.rb
+++ b/spec/controllers/locations/map_controller_spec.rb
@@ -47,7 +47,7 @@ module Locations
         let(:loc) { holding_location.code }
         let(:holding_location) { FactoryGirl.create(:holding_location_stackmap_closed, library_args: { code: 'stokes' }) }
 
-        before { stub_request(:get, map_bibdata).to_return(status: 200, body: '{}') }
+        before { stub_request(:get, map_bibdata).to_return(status: 200, body: "{\"id\": #{id}}") }
 
         it 'returns a message to user via index template' do
           get :index, params
@@ -57,6 +57,16 @@ module Locations
 
       context 'with invalid params' do
         let(:id) { 'Foo' }
+        let(:loc) { 'Bar!' }
+
+        it 'returns an Bad Request 400 error' do
+          get :index, params
+          expect(response.status).to eq 400
+        end
+      end
+
+      context 'when missing call number and id' do
+        let(:id) { nil }
         let(:loc) { 'Bar!' }
 
         it 'returns an Bad Request 400 error' do


### PR DESCRIPTION
Replaces #79. A 400 response is returned by the locator if it doesn't have access to a call number param or bibrecord (to retrieve call number or title).